### PR TITLE
Add QNH/QFE display mode setting

### DIFF
--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -1556,6 +1556,10 @@ void IpsDisplay::drawDisplay( int airspeed, float te, float ate, float polar_sin
 	if( _menu )
 		return;
 
+	if ( alt_display_mode.get() == MODE_QFE ) {
+		altitude -= elevation.get();
+	}
+
 	if( display_style.get() == DISPLAY_AIRLINER )
 		drawAirlinerDisplay( airspeed,te,ate, polar_sink, altitude, temp, volt, s2fd, s2f, acl, s2fmode, standard_setting, wksensor );
 	else if( display_style.get() == DISPLAY_RETRO )

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -760,6 +760,12 @@ void SetupMenu::setup( )
 		atl->addEntry( "Disable");
 		atl->addEntry( "Enable");
 
+		SetupMenuSelect * altDisplayMode = new SetupMenuSelect( "Altitude Mode", false, 0, true, &alt_display_mode );
+		opt->addMenu( altDisplayMode );
+		altDisplayMode->setHelp( PROGMEM "Select altitude display mode");
+		altDisplayMode->addEntry( "QNH");
+		altDisplayMode->addEntry( "QFE");
+
 		SetupMenuValFloat * tral = new SetupMenuValFloat( "Transition Altitude", 0, "FL", 0, 400, 10, 0, false, &transition_alt  );
 		tral->setHelp(PROGMEM"Transition altitude (or transition height, when using QFE) is the altitude/height above which standard pressure (QNE) is set (1013.2 mb/hPa)");
 		opt->addMenu( tral );

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -66,6 +66,7 @@ SetupNG<int>  			factory_reset( "FACTORY_RES" , 0 );
 SetupNG<int>  			audio_range( "AUDIO_RANGE" , AUDIO_RANGE_5_MS );
 SetupNG<int>  			alt_select( "ALT_SELECT" , 1 );
 SetupNG<int>  			fl_auto_transition( "FL_AUTO" , 0 );
+SetupNG<int>  			alt_display_mode( "ALT_DISPLAY_MODE" , MODE_QNH );
 SetupNG<float>  		transition_alt( "TRANS_ALT", 50 );   // Transition Altitude
 SetupNG<int>  			glider_type( "GLIDER_TYPE", 0 );
 SetupNG<int>  			ps_display( "PS_DISPLAY", 1 );

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -66,7 +66,7 @@ SetupNG<int>  			factory_reset( "FACTORY_RES" , 0 );
 SetupNG<int>  			audio_range( "AUDIO_RANGE" , AUDIO_RANGE_5_MS );
 SetupNG<int>  			alt_select( "ALT_SELECT" , 1 );
 SetupNG<int>  			fl_auto_transition( "FL_AUTO" , 0 );
-SetupNG<int>  			alt_display_mode( "ALT_DISPLAY_MODE" , MODE_QNH );
+SetupNG<int>  			alt_display_mode( "ALT_DISP_MODE" , MODE_QNH );
 SetupNG<float>  		transition_alt( "TRANS_ALT", 50 );   // Transition Altitude
 SetupNG<int>  			glider_type( "GLIDER_TYPE", 0 );
 SetupNG<int>  			ps_display( "PS_DISPLAY", 1 );

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -46,6 +46,7 @@ typedef enum chopping_mode { NO_CHOP, VARIO_CHOP, S2F_CHOP, BOTH_CHOP } chopping
 typedef enum rs232linemode { RS232_NORMAL, RS232_INVERTED } rs232lm_t;
 typedef enum nmea_protocol  { OPENVARIO, BORGELT, CAMBRIDGE, XCVARIO, XCVARIO_DEVEL, GENERIC } nmea_proto_t;
 typedef enum airspeed_mode  { MODE_IAS, MODE_TAS } airspeed_mode_t;
+typedef enum altitude_display_mode  { MODE_QNH, MODE_QFE } altitude_display_mode_t;
 typedef enum e_display_style  { DISPLAY_AIRLINER, DISPLAY_RETRO, DISPLAY_UL } display_style_t;
 typedef enum e_display_variant { DISPLAY_WHITE_ON_BLACK, DISPLAY_BLACK_ON_WHITE } display_variant_t;
 typedef enum e_s2f_type  { S2F_HW_SWITCH, S2F_HW_PUSH_BUTTON, S2F_HW_SWITCH_INVERTED } e_s2f_type;
@@ -299,6 +300,7 @@ extern SetupNG<int>  		factory_reset;
 extern SetupNG<int>  		audio_range;
 extern SetupNG<int>  		alt_select;
 extern SetupNG<int>  		fl_auto_transition;
+extern SetupNG<int>  		alt_display_mode;
 extern SetupNG<float>  		transition_alt;
 extern SetupNG<int>  		glider_type;
 extern SetupNG<int>  		ps_display;


### PR DESCRIPTION
In many gliding clubs QFE is still preferred over QNH. So it is a good idea to be able to see QFE on vario screen while still receiving correct QNH via NMEA output.