### PR TITLE
Revised Compass and wind diaply in ULStyle

### DIFF
--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -1002,6 +1002,65 @@ void IpsDisplay::drawCompass(){
 				else if( windspeed < 100 )
 					ucg->printf("%s  ", s);
 				else
+					ucg->printf("%s ", s);
+				prev_heading = winddir;
+			}
+		}
+		else if( compass_enable.get()  ){
+			bool ok;
+			int heading = static_cast<int>(rintf(Compass::trueHeading( &ok )));
+			if( heading >= 360 )
+				heading -= 360;
+			// ESP_LOGI(FNAME, "heading %d, valid %d", heading, Compass::headingValid() );
+			if( prev_heading != heading || !(tick%32) ){
+				ucg->setPrintPos(105,104);
+				ucg->setColor(  COLOR_WHITE  );
+				ucg->setFont(ucg_font_fub20_hr);
+				char s[12];
+				if( ok )
+					sprintf(s,"%3d", heading );
+				else
+					sprintf(s,"%s", "  ---" );
+
+				if( heading < 10 )
+					ucg->printf("%s   ", s);
+				else if( heading < 100 )
+					ucg->printf("%s  ", s);
+				else
+					ucg->printf("%s ", s);
+				ucg->setFont(ucg_font_fub20_hf);
+				ucg->setPrintPos(120+ucg->getStrWidth(s),105);
+				ucg->printf("\xb0 ");
+				prev_heading = heading;
+			}
+		}
+	}
+}
+
+
+// Compass or Wind Display
+void IpsDisplay::drawULCompass(){
+	if( compass_calibrated.get() ){
+		if( compass_enable.get() && wind_enable.get() ){
+			int winddir;
+			float wind;
+			bool ok = theWind.getWind( &winddir, &wind );
+			if( prev_heading != winddir || !(tick%32) ){
+				ucg->setPrintPos(85,104);
+				ucg->setColor(  COLOR_WHITE  );
+				// ucg->setFont(ucg_font_fub20_hr);
+				ucg->setFont(ucg_font_fub17_hf);
+				char s[12];
+				int windspeed = (int)( Units::Airspeed(wind)+0.5 );
+				if( ok )
+					sprintf(s,"%3d\xb0/%2d", winddir, windspeed );
+				else
+					sprintf(s,"%s", "    --/--" );
+				if( windspeed < 10 )
+					ucg->printf("%s   ", s);
+				else if( windspeed < 100 )
+					ucg->printf("%s  ", s);
+				else
 					ucg->printf("%s  ", s);
 				prev_heading = winddir;
 			}
@@ -1548,7 +1607,7 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	}
 	// Compass
 	if( !(tick%8) ){
-		drawCompass();
+		drawULCompass();
 	}
 	xSemaphoreGive(spiMutex);
 }

--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -1002,35 +1002,33 @@ void IpsDisplay::drawCompass(){
 				else if( windspeed < 100 )
 					ucg->printf("%s  ", s);
 				else
-					ucg->printf("%s ", s);
+					ucg->printf("%s  ", s);
 				prev_heading = winddir;
 			}
 		}
-		else if( compass_enable.get()  ){
+		if( compass_enable.get()  ){
 			bool ok;
 			int heading = static_cast<int>(rintf(Compass::trueHeading( &ok )));
 			if( heading >= 360 )
 				heading -= 360;
 			// ESP_LOGI(FNAME, "heading %d, valid %d", heading, Compass::headingValid() );
 			if( prev_heading != heading || !(tick%32) ){
-				ucg->setPrintPos(105,104);
+				
 				ucg->setColor(  COLOR_WHITE  );
-				ucg->setFont(ucg_font_fub20_hr);
-				char s[12];
+				if ( wind_enable.get () ){
+				  ucg->setFont(ucg_font_fub17_hf);
+				  ucg->setPrintPos(105,129);
+				}
+				else{
+				  ucg->setFont(ucg_font_fub20_hf);
+				  ucg->setPrintPos(105,105);
+				}
+				char s[14];
 				if( ok )
-					sprintf(s,"%3d", heading );
+					sprintf(s,"%3d\xb0", heading );
 				else
 					sprintf(s,"%s", "  ---" );
-
-				if( heading < 10 )
-					ucg->printf("%s   ", s);
-				else if( heading < 100 )
-					ucg->printf("%s  ", s);
-				else
-					ucg->printf("%s ", s);
-				ucg->setFont(ucg_font_fub20_hf);
-				ucg->setPrintPos(120+ucg->getStrWidth(s),105);
-				ucg->printf("\xb0 ");
+				ucg->printf("%s    ", s);
 				prev_heading = heading;
 			}
 		}

--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -1038,7 +1038,7 @@ void IpsDisplay::drawCompass(){
 }
 
 
-// Compass or Wind Display
+// Compass or Wind Display ULStyle
 void IpsDisplay::drawULCompass(){
 	if( compass_calibrated.get() ){
 		if( compass_enable.get() && wind_enable.get() ){
@@ -1074,14 +1074,8 @@ void IpsDisplay::drawULCompass(){
 			if( prev_heading != heading || !(tick%32) ){
 				
 				ucg->setColor(  COLOR_WHITE  );
-				if ( wind_enable.get () ){
-				  ucg->setFont(ucg_font_fub17_hf);
-				  ucg->setPrintPos(105,129);
-				}
-				else{
-				  ucg->setFont(ucg_font_fub20_hf);
-				  ucg->setPrintPos(105,105);
-				}
+     			  	ucg->setFont(ucg_font_fub20_hf);
+				ucg->setPrintPos(113,220);
 				char s[14];
 				if( ok )
 					sprintf(s,"%3d\xb0", heading );

--- a/main/IpsDisplay.h
+++ b/main/IpsDisplay.h
@@ -42,6 +42,7 @@ public:
 	static void drawArrowBox( int x, int y, bool are=true );
 	static void redrawValues();
 	static void drawCompass();
+	static void drawULCompass();
 	static inline Ucglib_ILI9341_18x240x320_HWSPI *getDisplay() { return ucg; };
 
 private:


### PR DESCRIPTION
I used the free area in ULStyle display to allow for simultaneous display of heading and wind information, if enabled.
Corrected some minor artifacts with rapid heading change and did some polishing of fontsize and position.
Not sure, if there is some mileage in allowing this also in Retro-Display. seems to be to crowded.  