### PR TITLE
Revert "A lot of ideas for the retro display"

### DIFF
--- a/main/Colors.h
+++ b/main/Colors.h
@@ -18,7 +18,6 @@ extern int g_col_header_light_b;
 #define COLOR_BLACK g_col_background, g_col_background, g_col_background
 #define COLOR_GREEN 255, 30, 255
 #define COLOR_RED   0,255,255
-#define COLOR_ORANGE 0,125,255
 #define LIGHT_GREEN 127,0,255
 #define COLOR_YELLOW 0, 0, 255
 #define DARK_GREY    230, 230, 230

--- a/main/Flap.cpp
+++ b/main/Flap.cpp
@@ -352,7 +352,6 @@ void Flap::drawBigBar( int ypos, int xpos, float wkf, float wksens ){
 			// print digit
 			ucg->printf(position);
 			// Frame around digit
-			ucg->setColor(COLOR_HEADER);
 			ucg->drawFrame(xpos-2, y-(lfh/2), lfw+6, lfh );
 		}
 		surroundingBox = true;
@@ -616,8 +615,7 @@ void  Flap::initSensPos(){
 	}
 }
 
-// > airspeed in kmh corrected for actual wing load to match the wk setup speeds
-// < optimal wk respecting g-load, idx of wk setting
+
 float Flap::getOptimum( float wks, int& wki )
 {
 	// Correct for current g load

--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -36,9 +36,16 @@ int   IpsDisplay::red = 10;
 int   IpsDisplay::yellow = 25;
 
 float IpsDisplay::old_a = 0;
+int IpsDisplay::x_0 = 0;
+int IpsDisplay::y_0 = 0;
+int IpsDisplay::x_1 = 0;
+int IpsDisplay::y_1 = 0;
+int IpsDisplay::x_2 = 0;
+int IpsDisplay::y_2 = 0;
+int IpsDisplay::x_3 = 0;
+int IpsDisplay::y_3 = 0;
 
 bool IpsDisplay::netto_old = false;
-ucg_int_t IpsDisplay::char_width;
 
 #define DISPLAY_H 320
 #define DISPLAY_W 240
@@ -55,7 +62,7 @@ const int   S2F_TRISIZE = 60; // triangle size quality up/down
 #define TRISIZE 15
 
 #define FIELD_START 85
-#define FIELD_START_UL 170
+#define FIELD_START_UL_AS 185
 #define SIGNLEN 24+4
 #define GAP 12
 
@@ -74,7 +81,7 @@ const int   S2F_TRISIZE = 60; // triangle size quality up/down
 
 #define YALT (YS2F+S2FFONTH+HEADFONTH+GAP+2*MAXS2FTRI +22 )
 
-#define BATX (DISPLAY_W-10)
+#define BATX (DISPLAY_W-15)
 #define BATY (DISPLAY_H-15)
 #define LOWBAT  11.6    // 20%  -> 0%
 #define FULLBAT 12.8    // 100%
@@ -94,11 +101,11 @@ int S2FST = 45;
 
 
 int ASLEN = 0;
-#define AMIDY DISPLAY_H/2
-#define AMIDX (DISPLAY_W/2 + 30)
+#define AMIDY 160
+#define AMIDX 140
 static int fh;
 
-extern xSemaphoreHandle spiMutex; // todo needs a better concept here
+extern xSemaphoreHandle spiMutex;
 
 #define PMLEN 24
 
@@ -113,7 +120,7 @@ int IpsDisplay::_ate=0;
 int IpsDisplay::s2falt=-1;
 int IpsDisplay::s2fdalt=0;
 int IpsDisplay::s2fmode_prev=100;
-int IpsDisplay::alt_prev=0;
+int IpsDisplay::prefalt=0;
 int IpsDisplay::chargealt=-1;
 int IpsDisplay::btqueue=-1;
 int IpsDisplay::tempalt = -2000;
@@ -138,7 +145,7 @@ float IpsDisplay::_range = 5;
 int   IpsDisplay::average_climb = -100;
 float IpsDisplay::average_climbf = 0;
 int   IpsDisplay::prev_heading = 0;
-float IpsDisplay::pref_qnh = 0;
+float   IpsDisplay::pref_qnh = 0;
 
 #define WKBARMID (AMIDY-15)
 
@@ -243,9 +250,9 @@ void IpsDisplay::initDisplay() {
 	if ( display_variant.get() == DISPLAY_WHITE_ON_BLACK ) {
 		g_col_background = 255;
 		g_col_highlight = 0;
-		g_col_header_r=179;
-		g_col_header_g=171;
-		g_col_header_b=164;
+		g_col_header_r=154;
+		g_col_header_g=147;
+		g_col_header_b=0;
 		g_col_header_light_r=94;
 		g_col_header_light_g=87;
 		g_col_header_light_b=0;
@@ -253,9 +260,9 @@ void IpsDisplay::initDisplay() {
 	else {
 		g_col_background = 0;
 		g_col_highlight = 255;
-		g_col_header_r=179;
-		g_col_header_g=171;
-		g_col_header_b=164;
+		g_col_header_r=101;
+		g_col_header_g=108;
+		g_col_header_b=255;
 		g_col_header_light_r=161;
 		g_col_header_light_g=168;
 		g_col_header_light_b=255;
@@ -280,8 +287,13 @@ void IpsDisplay::initDisplay() {
 		bootDisplay();
 		ucg->setFontPosBottom();
 		ucg->setPrintPos(20,YVAR-VARFONTH+7);
-		ucg->setColor( COLOR_HEADER );
-        ucg->print(Units::VarioUnit());
+		ucg->setColor(0, COLOR_HEADER );
+		if( UNITVAR == 0 ) // m/s
+			ucg->print("  m/s");
+		if( UNITVAR == 1 ) // ft/min
+			ucg->print("cft/m");
+		if( UNITVAR == 2 ) // knots
+			ucg->print("knots");
 		ucg->setPrintPos(FIELD_START,YVAR-VARFONTH);    // 65 -52 = 13
 
 		ucg->print("AV Vario");
@@ -321,14 +333,8 @@ void IpsDisplay::initDisplay() {
 		ucg->drawTriangle( FIELD_START+ASLEN-1, dmid, FIELD_START+ASLEN+5, dmid-6, FIELD_START+ASLEN+5, dmid+6);
 
 		// Thermometer
-		drawThermometer(  FIELD_START+10, DISPLAY_H-6 );
-
+		drawThermometer(  FIELD_START+10, DISPLAY_H-4 );
 	}
-
-	// Fancy altimeter
-	ucg->setFont(ucg_font_fub20_hr);
-	char_width = ucg->getStrWidth("2");
-
 	redrawValues();
 }
 
@@ -410,15 +416,15 @@ void IpsDisplay::drawAvgSymbol( int y, int r, int g, int b, int x ) {
 	ucg->drawTetragon( x+size-1,dmid-y, x,dmid-y+size, x-size,dmid-y, x,dmid-y-size );
 }
 
+float avc_old=-1000;
+int yusize=7;
+int ylsize=7;
+
 void IpsDisplay::drawAvg( float avclimb, float delta ){
-	static float avc_old=-1000;
-	static int yusize=7;
-	static int ylsize=7;
 	if( _menu )
 		return;
-
 	ESP_LOGD(FNAME,"drawAvg: av=%.2f delta=%.2f", avclimb, delta );
-	int pos=145;
+	int pos=130;
 	int size=7;
 	if( avc_old != -1000 ){
 		ucg->setColor( COLOR_BLACK );
@@ -470,7 +476,7 @@ void IpsDisplay::redrawValues()
 	mcalt = -100;
 	as_prev = -1;
 	_ate = -200;
-	alt_prev = -1;
+	prefalt = -1;
 	pref_qnh = -1;
 	tyalt = 0;
 	for( int l=TEMIN-1; l<=TEMAX; l++){
@@ -542,31 +548,27 @@ void IpsDisplay::setTeBuf( int y1, int h, int r, int g, int b ){
 void IpsDisplay::drawMC( float mc, bool large ) {
 	if( _menu )
 		return;
-	ucg->setPrintPos(5, DISPLAY_H-5);
-	ucg->setColor(COLOR_WHITE);
-	if( large ) {
-		ucg->setFont(ucg_font_fub20_hn);
-    } else {
-		ucg->setFont(ucg_font_fub14_hn);
-    }
-    char s[10];
-	std::sprintf(s, "%1.1f", mc );
-    ucg->printf(s);
-    ucg_int_t fl = ucg->getStrWidth(s);
 	ucg->setFont(ucg_font_fub11_hr);
+	ucg->setPrintPos(5,DISPLAY_H-6);
 	ucg->setColor(COLOR_HEADER);
-	ucg->setPrintPos(5+fl, DISPLAY_H-6);
-	ucg->printf(" MC");
+	ucg->printf("MC:");
+	ucg->setPrintPos(5+ucg->getStrWidth("MC:"),DISPLAY_H-4);
+	ucg->setColor(COLOR_WHITE);
+	if( large )
+		ucg->setFont(ucg_font_fub20_hn);
+	else
+		ucg->setFont(ucg_font_fub14_hn);
+	ucg->printf("%1.1f", mc );
 }
 
-#define S2FSS 10
-#define S2FTS 5
+#define S2FSS 16
+#define S2FTS 6
 
 void IpsDisplay::drawCircling( int x, int y, bool draw ){
 	if( _menu )
 		return;
 	if( draw )
-		ucg->setColor( COLOR_HEADER );
+		ucg->setColor( COLOR_WHITE );
 	else
 		ucg->setColor( COLOR_BLACK );
 	ucg->drawCircle( x, y, S2FSS,   UCG_DRAW_ALL );
@@ -579,11 +581,11 @@ void IpsDisplay::drawCruise( int x, int y, bool draw ){
 	if( _menu )
 		return;
 	if( draw )
-		ucg->setColor( COLOR_HEADER );
+		ucg->setColor( COLOR_WHITE );
 	else
 		ucg->setColor( COLOR_BLACK );
 	ucg->drawTetragon(x-S2FSS,y-5, x-S2FSS,y-1, x+S2FSS,y+5, x+S2FSS,y+1 );
-	ucg->drawTriangle( x+S2FSS-10, y+7, x+S2FSS-8, y-4, x+S2FSS, y+3 );
+	ucg->drawTriangle( x+6, y+7, x+8, y-4, x+S2FSS, y+3 );
 }
 
 void IpsDisplay::drawS2FMode( int x, int y, bool cruise ){
@@ -598,69 +600,6 @@ void IpsDisplay::drawS2FMode( int x, int y, bool cruise ){
 		drawCruise(x,y,false);
 		drawCircling(x,y,true);
 	}
-}
-
-void IpsDisplay::drawArrow(int x, int y, int level, bool del)
-{
-	const int width=40;
-	const int step=8;
-	const int gap=2;
-	int height=step;
-
-    if ( level == 0 ) return;
-
-	if( del ) {
-		ucg->setColor( COLOR_BLACK );
-	}
-	else {
-		if ( std::abs(level) == 4 ) {
-			height=3;
-			ucg->setColor( COLOR_ORANGE );
-		}
-		else {
-			if( level < 0 ) {
-				ucg->setColor( COLOR_GREEN );
-			} else {
-				ucg->setColor( COLOR_BLUE );
-			}
-		}
-	}
-	int l = level-1;
-    if ( level < 0 ) {
-        height = -height;
-        l = level+1;
-    }
-	// ucg->drawTetragon(x,y+level*(step+gap), x+width,y+level*gap, x,y+level*(step+gap)+height, x-width, y+level*gap);
-	ucg->drawTriangle(x,y+l*(step+gap), x,y+l*(step+gap)+height, x-width, y+l*gap);
-	ucg->drawTriangle(x,y+l*(step+gap), x+width,y+l*gap, x,y+l*(step+gap)+height);
-}
-
-// speed to fly delta in kmh, s2fd > 0 means speed up
-void IpsDisplay::drawS2FBar(int x, int y, int s2fd)
-{
-	static int level_old = 0;
-	int level = s2fd/10;
-
-	// draw max. three bars plus a yellow top
-	if ( level > 4 ) { level = 4; }
-	else if ( level < -4 ) { level = -4; }
-
-	if ( level == level_old ) {
-		return;
-	}
-
-	int inc = (level-level_old > 0) ? 1 : -1;
-	int i = level_old + ((level_old==0 || level_old*inc>0) ? inc : 0);
-    do {
-		if ( i != 0 ) {
-			drawArrow(x, y-2+(i>0?1:-1)*22, i, (i*inc < 0));
-        	ESP_LOGI(FNAME,"s2fbar draw %d,%d", i, (i*inc < 0));
-		}
-		if ( i == level ) break;
-		i+=inc;
-	}
-    while ( i != level );
-    level_old = level;
 }
 
 void IpsDisplay::drawBT() {
@@ -688,27 +627,6 @@ void IpsDisplay::drawBT() {
 		btqueue = btq;
 		flarm_connected = Flarm::connected();
 	}
-	if( SetupCommon::isWired() ) {
-		drawCable(DISPLAY_W-30, BTH + 27);
-	}
-}
-
-void IpsDisplay::drawCable(int x, int y)
-{
-    CAN->connectedXCV() ? ucg->setColor( COLOR_LBLUE ) : ucg->setColor(COLOR_MGREY);
-    ucg->setFont(ucg_font_fub11_hr);
-    ucg->setPrintPos(x-8,y);
-    if( CAN->connectedMagSens() ) {
-        ucg->setColor( COLOR_GREEN );
-    }
-    ucg->printf("C");
-    CAN->connectedMagSens() ? ucg->setColor( COLOR_LBLUE ) : ucg->setColor(COLOR_MGREY);
-    if( Flarm::connected() ) {
-        ucg->setColor( COLOR_GREEN );
-    }
-    ucg->printf("A");
-    CAN->connectedXCV() ? ucg->setColor( COLOR_LBLUE ) : ucg->setColor(COLOR_MGREY);
-    ucg->printf("N");
 }
 
 void IpsDisplay::drawFlarm( int x, int y, bool flarm ) {
@@ -761,19 +679,19 @@ void IpsDisplay::drawWifi( int x, int y ) {
 		flarm_connected = Flarm::connected();
 		btqueue = btq;
 	}
-	if( SetupCommon::isWired() ) {
-		drawCable(x-6, y+22);
-	}
 }
 
-void IpsDisplay::drawConnection( int x, int y )
-{
-	if( wireless == WL_BLUETOOTH )
-		drawBT();
-	else if( wireless != WL_DISABLE )
-		drawWifi(x, y);
-	else if( SetupCommon::isWired() )
-		drawCable(x, y);
+void IpsDisplay::drawCAN( int x, int y ) {
+	if( _menu )
+		return;
+	if( can_speed.get() != CAN_SPEED_OFF ){
+		ucg->setColor(COLOR_MGREY);
+		if( CAN->connected() )
+			ucg->setColor( COLOR_LBLUE );
+		ucg->setFont(ucg_font_fub11_hr);
+		ucg->setPrintPos(x,y);
+		ucg->printf("can");
+	}
 }
 
 void IpsDisplay::drawBat( float volt, int x, int y, bool blank ) {
@@ -803,7 +721,6 @@ void IpsDisplay::drawBat( float volt, int x, int y, bool blank ) {
 		}
 		ucg->setColor( COLOR_WHITE );
 		if ( battery_display.get() != BAT_VOLTAGE_BIG ){
-			ucg->setColor( COLOR_HEADER );
 			ucg->drawBox( x-40,y-2, 36, 12  );  // Bat body square
 			ucg->drawBox( x-4, y+1, 3, 6  );      // Bat pluspole pimple
 			if ( charge > yellow )  // >25% grün
@@ -820,10 +737,10 @@ void IpsDisplay::drawBat( float volt, int x, int y, bool blank ) {
 			ucg->drawBox( x-40+2,y, chgpos, 8  );  // Bat charge state
 			ucg->setColor( DARK_GREY );
 			ucg->drawBox( x-40+2+chgpos,y, 32-chgpos, 8 );  // Empty bat bar
+			ucg->setColor( COLOR_WHITE );
 			ucg->setFont(ucg_font_fub11_hr);
-			ucg->setPrintPos(x-42,y-6);
+			ucg->setPrintPos(x-40,y-7);
 		}
-		ucg->setColor( COLOR_HEADER );
 		if( battery_display.get() == BAT_PERCENTAGE )
 			ucg->printf("%3d%%  ", charge);
 		else if ( battery_display.get() == BAT_VOLTAGE ) {
@@ -831,7 +748,7 @@ void IpsDisplay::drawBat( float volt, int x, int y, bool blank ) {
 			ucg->printf("%2.1f V", volt);
 		}
 		else if ( battery_display.get() == BAT_VOLTAGE_BIG ) {
-			ucg->setPrintPos(x-50,y+11);
+			ucg->setPrintPos(x-60,y+8);
 			ucg->setFont(ucg_font_fub14_hr);
 			ucg->printf("%2.1fV", volt);
 		}
@@ -843,54 +760,32 @@ void IpsDisplay::drawTemperature( int x, int y, float t ) {
 	if( _menu )
 		return;
 	ucg->setFont(ucg_font_fur14_hf);
+	ucg->setColor( COLOR_WHITE );
 	ucg->setPrintPos(x,y);
-	if( t != DEVICE_DISCONNECTED_C ) {
-		ucg->setColor( COLOR_WHITE );
-		ucg->printf("%-2.1f", std::roundf(t*10.f)/10.f );
-		ucg->setColor( COLOR_HEADER );
-		ucg->printf("\xb0""C  ");
-	}
-	else {
-		ucg->setColor( COLOR_HEADER );
-		ucg->printf(" -- \xb0""C  ");
-    }
+	if( t != DEVICE_DISCONNECTED_C )
+		ucg->printf("%-2.1f\xb0""  ", std::roundf(t*10.f)/10.f );
+	else
+		ucg->printf(" ---   ");
 }
 
-// val, center x, y, start radius, end radius, width, r,g,b, clenaup
-void IpsDisplay::drawPolarIndicator( float a, int x0, int y0, int l1, int l2, int w, int r, int g, int b, bool del )
-{
-	static ucg_int_t x_0 = 0;
-	static ucg_int_t y_0 = 0;
-	static ucg_int_t x_1 = 0;
-	static ucg_int_t y_1 = 0;
-	static ucg_int_t x_2 = 0;
-	static ucg_int_t y_2 = 0;
-	static ucg_int_t x_3 = 0;
-	static ucg_int_t y_3 = 0;
-	static ucg_int_t x_tip = 0;
-	static ucg_int_t y_tip = 0;
-
-	if( _menu ) return;
-
-	ucg_int_t w0 = del?w+2:w;
+void IpsDisplay::drawTetragon( float a, int x0, int y0, int l1, int l2, int w, int r, int g, int b, bool del ){
+	if( _menu )
+		return;
 	float si=sin(a);
 	float co=cos(a);
-	ucg_int_t xn_0 = x0-l1*co+w0*si;
-	ucg_int_t yn_0 = y0-l1*si-w0*co;
-	ucg_int_t xn_1 = x0-l1*co-w0*si;
-	ucg_int_t yn_1 = y0-l1*si+w0*co;
-	ucg_int_t xn_2 = x0-l2*co-w*si;
-	ucg_int_t yn_2 = y0-l2*si+w*co;
-	ucg_int_t xn_3 = x0-l2*co+w*si;
-	ucg_int_t yn_3 = y0-l2*si-w*co;
-	ucg_int_t x_ntip = x0-(l2+2)*co;
-	ucg_int_t y_ntip = y0-(l2+2)*si;
+	int w2=w;
+	int xn_0 = x0-l1*co+w2*si;
+	int yn_0 = y0-l1*si-w2*co;
+	int xn_1 = x0-l1*co-w2*si;
+	int yn_1 = y0-l1*si+w2*co;
+	int xn_2 = x0-l2*co-w2*si;
+	int yn_2 = y0-l2*si+w2*co;
+	int xn_3 = x0-l2*co+w2*si;
+	int yn_3 = y0-l2*si-w2*co;
 	// ESP_LOGI(FNAME,"IpsDisplay::drawTetragon  x0:%d y0:%d x1:%d y1:%d x2:%d y2:%d x3:%d y3:%d", (int)xn_0, (int)yn_0, (int)xn_1 ,(int)yn_1, (int)xn_2, (int)yn_2, (int)xn_3 ,(int)yn_3 );
-	if( del ) {
-		// cleanup previous incarnation
+	if( del ) {  // cleanup previous incarnation
 		ucg->setColor(  COLOR_BLACK  );
 		ucg->drawTetragon(x_0,y_0,x_1,y_1,x_2,y_2,x_3,y_3);
-		ucg->drawDisc(x_tip, y_tip, 2*w, UCG_DRAW_ALL);
 		x_0 = xn_0;
 		y_0 = yn_0;
 		x_1 = xn_1;
@@ -899,13 +794,10 @@ void IpsDisplay::drawPolarIndicator( float a, int x0, int y0, int l1, int l2, in
 		y_2 = yn_2;
 		x_3 = xn_3;
 		y_3 = yn_3;
-		x_tip = x_ntip;
-		y_tip = y_ntip;
 		old_a = a;
 	}
 	ucg->setColor( r,g,b  );
 	ucg->drawTetragon(xn_0,yn_0,xn_1,yn_1,xn_2,yn_2,xn_3,yn_3);
-	if ( del ) ucg->drawDisc(x_ntip, y_ntip, 2*w, UCG_DRAW_ALL);
 }
 
 void IpsDisplay::drawScaleLines( bool full, float max_pos, float max_neg ){
@@ -921,47 +813,46 @@ void IpsDisplay::drawScaleLines( bool full, float max_pos, float max_neg ){
 		lower = (int)max_neg;
 	for( float a=lower; a<=(int)max_pos; a+=modulo ) {
 		int width=1;
-		int end=150;
+		int end=135;
 		int r = (int)max_pos;
 		if( a==0 || abs(a)==r ){
 			width=2;
-			end=155;
+			end=140;
 		}
 		if((r%2) == 0) {
 			if(abs(a)==r/2){  // half scale big line
 				width = 2;
-				end=155;
+				end=140;
 			}
 		}
 		else{
 			if( abs(a) == (r-1)/2 ){  // half scale minus one for even ranges big line
 				width = 2;
-				end=155;
+				end=140;
 			}
 		}
 		if( modulo < 1 ){
 			if( fmod(a,1) == 0 ){  // every integer big line
 				width = 2;
-				end=155;
+				end=140;
 			}
 		}
-		drawPolarIndicator( ((float)a/max_pos)*M_PI_2, AMIDX, AMIDY, 140, end, width, COLOR_WHITE, false );
+		drawTetragon( ((float)a/max_pos)*M_PI_2, AMIDX, AMIDY, 125, end, width, COLOR_WHITE, false );
 	}
 }
 
 // Draw scale numbers for positive or negative value
-void IpsDisplay::annotateScale( int val, int pos, float range, int offset ){
+void IpsDisplay::drawAnalogScale( int val, int pos, float range, int offset ){
 	if( _menu )
 		return;
 	ucg->setFontPosCenter();
 	ucg->setFont(ucg_font_fub14_hn);
-	const float to_side = 1.07;
-	int x=AMIDX - cos((val*to_side/range)*M_PI_2)*pos;
-	int y=AMIDY+1 - sin((val*to_side/range)*M_PI_2)*pos;
+	int x=AMIDX - cos((val/range)*M_PI_2)*pos;
+	int y=AMIDY+1 - sin((val/range)*M_PI_2)*pos;
 	if( val > 0 )
-		ucg->setPrintPos(x-17,y);
+		ucg->setPrintPos(x-15,y);
 	else
-		ucg->setPrintPos(x-10,y);
+		ucg->setPrintPos(x-8,y);
 	ucg->printf("%+d", val+offset );
 	ucg->setFontPosBottom();
 }
@@ -1033,22 +924,25 @@ void IpsDisplay::initULDisplay(){
 	redrawValues();
 	drawScaleLines( true, _range, -_range );
 	int r = (int)_range;
-	annotateScale(-r,150, _range );
-	annotateScale(r,150, _range);
+	drawAnalogScale(-r,150, _range );
+	drawAnalogScale(r,150, _range);
 	// drawAnalogScale(0, 132);
 	if((r%2) == 0) {
-		annotateScale(r/2,155, _range);
-		annotateScale(-r/2,155, _range);
+		drawAnalogScale(r/2,150, _range);
+		drawAnalogScale(-r/2,155, _range);
 	}
 	else{
-		annotateScale((r-1)/2,155, _range);
-		annotateScale((-r+1)/2,155, _range);
+		drawAnalogScale((r-1)/2,150, _range);
+		drawAnalogScale((-r+1)/2,155, _range);
 	}
 	// Unit's
 	ucg->setFont(ucg_font_fub11_hr);
 	ucg->setPrintPos(85,15);
 	ucg->print( Units::VarioUnit() );
-	drawConnection(DISPLAY_W-27, FLOGO+2 );
+	if( wireless == WL_BLUETOOTH )
+		drawBT();
+	else
+		drawWifi(DISPLAY_W-27, FLOGO+2 );
 	drawThermometer(  10, 30 );
 }
 
@@ -1061,24 +955,30 @@ void IpsDisplay::initRetroDisplay(){
 	redrawValues();
 	drawScaleLines( true, _range, -_range );
 	int r = (int)_range;
-	annotateScale(-r,150, _range );
-	annotateScale(r,150, _range);
+	drawAnalogScale(-r,150, _range );
+	drawAnalogScale(r,150, _range);
 	// drawAnalogScale(0, 132);
 	if((r%2) == 0) {
-		annotateScale(r/2,155, _range);
-		annotateScale(-r/2,155, _range);
+		drawAnalogScale(r/2,150, _range);
+		drawAnalogScale(-r/2,155, _range);
 	}
 	else{
-		annotateScale((r-1)/2,155, _range);
-		annotateScale((-r+1)/2,155, _range);
+		drawAnalogScale((r-1)/2,150, _range);
+		drawAnalogScale((-r+1)/2,155, _range);
 	}
 	// Unit's
 	ucg->setFont(ucg_font_fub11_hr);
-	ucg->setPrintPos(5,50);
-    ucg->setColor(COLOR_HEADER);
+	ucg->setPrintPos(85,15);
+	if( _menu )
+		return;
 	ucg->print( Units::VarioUnit() );
-	drawConnection(DISPLAY_W-27, FLOGO+2 );
+	if( wireless == WL_BLUETOOTH )
+		drawBT();
+	else
+		drawWifi(DISPLAY_W-27, FLOGO+2 );
 	drawMC( MC.get(), true );
+	drawThermometer(  10, 30 );
+	// ucg->scrollSetMargins( 0, 0 );
 }
 
 void IpsDisplay::drawWarning( const char *warn, bool push ){
@@ -1122,96 +1022,26 @@ void IpsDisplay::drawAvgVario( int x, int y, float ate ){
 	ucg->setFontPosBottom();
 	ucg->undoClipRange();
 }
-// right-aligned to value, unit optional behind
-void IpsDisplay::drawAltitude( float altitude, ucg_int_t x, ucg_int_t y, bool incl_unit )
-{
 
-	int alt = (int)(altitude*10.); // redered value
-	if ( alt_unit.get() == ALT_UNIT_FL ) { alt /= 10; }
-
-	// check on the rendered value for change
-	if ( alt == alt_prev ) return;
-
-	char s[15];
-	ucg->setFont(ucg_font_fub20_hr);
-	ucg->setColor( COLOR_WHITE );
-	sprintf(s,"%5d", alt);
-	int fl=ucg->getStrWidth(s);
-	if ( alt_unit.get() == ALT_UNIT_FL ) {
-		ucg->setPrintPos(x-fl,y);
-        ucg->printf(s);
-	}
-    else {
-		int len = std::strlen(s);
-		int16_t fraction = len>0?s[len-1]-'0':0;
-
-		alt /= 10; // chop fraction and last actual digit
-		char ldigit = '0' + (alt%10);
-		alt /= 10; // chop last actual digit
-		// snapy second last digit
-		if ( (ldigit=='0') && fraction<3 ) { alt -= 1; }
-		if ( (ldigit=='9') && fraction>7 ) { alt += 1; }
-		sprintf(s,"%5d8", alt);
-		fl=ucg->getStrWidth(s);
-		s[std::strlen(s)-1] = '\0'; // len(s) > 0 ensured!
-		ucg->setPrintPos(x - fl, y);
-		static int altpart_prev = 0;
-		if (altpart_prev != alt) {
-			ucg->printf(s);
-			altpart_prev = alt;
+void IpsDisplay::drawAltitude( float altitude, int x, int y ){
+	if( _menu )
+		return;
+	int alt = (int)(altitude);
+	if( alt != prefalt || !(tick%40) ) {
+		ucg->setColor(  COLOR_WHITE  );
+		ucg->setPrintPos(x,y);
+		ucg->setFont(ucg_font_fub25_hr);
+		if( UNITALT == 0 ) { //m
+			ucg->printf("%-4d %s   ", alt, Units::AltitudeUnit() );
 		}
-		// ESP_LOGI(FNAME,"Alti %d, fr%d - %c", alt, fraction, ldigit);
-
-		static int fraction_prev = -1;
-		if (fraction != fraction_prev)
-		{
-			// move last digit
-			int16_t char_height = ucg->getFontAscent() - ucg->getFontDescent();
-			int16_t m = (fraction / 10.f) * char_height; // to pixel offest
-			ucg->setClipRange(x - char_width, y - char_height * 1.3,
-							 char_width, char_height * 1.5);
-			// ucg->drawFrame(x - char_width, y - char_height * 1.3,
-			// 				 char_width, char_height * 1.5);
-			ucg->setPrintPos(x - char_width, y - m);
-			ucg->print(ldigit);
-			ucg->setPrintPos(x - char_width, y - m - char_height);
-			ucg->print((ldigit == '0') ? '9' : (char)(ldigit - 1)); // one above
-			ucg->setPrintPos(x - char_width, y - m + char_height);
-			ucg->print((ldigit == '9') ? '0' : (char)(ldigit + 1)); // one below
-			ucg->undoClipRange();
-			fraction_prev = fraction;
+		if( UNITALT == 1 ){ //feet
+			ucg->printf("%-5d %s   ", (alt/10)*10, Units::AltitudeUnit() );
 		}
+		if( UNITALT == 2 ){ //FL
+			ucg->printf("%s %-4d   ", Units::AltitudeUnit(), alt  );
+		}
+		prefalt = alt;
 	}
-	if ( incl_unit ) {
-		ucg->setFont(ucg_font_fub11_hr);
-		ucg->setColor( COLOR_HEADER );
-		ucg->setPrintPos(x, y-3);
-		ucg->printf(" %s ", Units::AltitudeUnit() );
-	}
-	alt_prev = alt;
-}
-// right-aligned to value, unit optional behind
-void IpsDisplay::drawSpeed(int airspeed, ucg_int_t x, ucg_int_t y, bool inc_unit)
-{
-	// ESP_LOGI(FNAME,"draw airspeed %d %d", airspeed, as_prev );
-	ucg->setColor( COLOR_WHITE );
-	if ( inc_unit ) { // todo shortcut
-		ucg->setFont(ucg_font_fub20_hr);
-	} else {
-		ucg->setFont(ucg_font_fub14_hn);
-	}
-	char s[10];
-	sprintf(s," %3d",  airspeed );
-	int fl=ucg->getStrWidth(s);
-	ucg->setPrintPos(x-fl,y);
-	ucg->printf(s);
-	if ( inc_unit ) {
-		ucg->setFont(ucg_font_fub11_hr);
-		ucg->setPrintPos(x,y-3);
-		ucg->setColor( COLOR_HEADER );
-		ucg->printf(" %s ", Units::AirspeedUnit() );
-	}
-	as_prev = airspeed;
 }
 
 int max_gscale = 0;
@@ -1234,22 +1064,22 @@ void IpsDisplay::initLoadDisplay(){
 		max_gscale = (int)( -gload_neg_limit.get()  )+1;
 	drawScaleLines( true, max_gscale, -max_gscale );
 
-	annotateScale(-max_gscale,150,max_gscale, 1 );
-	annotateScale(max_gscale,150,max_gscale, 1 );
+	drawAnalogScale(-max_gscale,150,max_gscale, 1 );
+	drawAnalogScale(max_gscale,150,max_gscale, 1 );
 	// drawAnalogScale(0, 132);
 	if((max_gscale%2) == 0) {
-		annotateScale(max_gscale/2,155,max_gscale, 1);
-		annotateScale(-max_gscale/2,155,max_gscale, 1);
+		drawAnalogScale(max_gscale/2,150,max_gscale, 1);
+		drawAnalogScale(-max_gscale/2,155,max_gscale, 1);
 	}
 	else{
-		annotateScale((max_gscale-1)/2,155,max_gscale, 1);
-		annotateScale((-max_gscale+1)/2,155,max_gscale, 1);
+		drawAnalogScale((max_gscale-1)/2,150,max_gscale, 1);
+		drawAnalogScale((-max_gscale+1)/2,155,max_gscale, 1);
 	}
 	for( float a=gload_pos_limit.get()-1; a<max_gscale; a+=0.05 ) {
-		drawPolarIndicator( ((float)a/max_gscale)*M_PI_2, AMIDX, AMIDY, 120, 130, 2, COLOR_RED, false );
+		drawTetragon( ((float)a/max_gscale)*M_PI_2, AMIDX, AMIDY, 120, 130, 2, COLOR_RED, false );
 	}
 	for( float a=gload_neg_limit.get()-1; a>(-max_gscale); a-=0.05 ) {
-		drawPolarIndicator( ((float)a/max_gscale)*M_PI_2, AMIDX, AMIDY, 120, 130, 2, COLOR_RED, false );
+		drawTetragon( ((float)a/max_gscale)*M_PI_2, AMIDX, AMIDY, 120, 130, 2, COLOR_RED, false );
 	}
 
 	ESP_LOGI(FNAME,"initLoadDisplay end");
@@ -1271,7 +1101,7 @@ void IpsDisplay::drawLoadDisplay( float loadFactor ){
 	// draw G pointer
 	float a = (loadFactor-1)/max_gscale * (M_PI_2);
 	if( int(a*100) != int(old_a*100) ) {
-		drawPolarIndicator( a, AMIDX, AMIDY, 60, 120, 3, COLOR_WHITE );
+		drawTetragon( a, AMIDX, AMIDY, 60, 120, 3, COLOR_WHITE );
 		// ESP_LOGI(FNAME,"IpsDisplay::drawRetroDisplay  TE=%0.1f  x0:%d y0:%d x2:%d y2:%d", te, x0, y0, x2,y2 );
 	}
 	// G load digital
@@ -1519,6 +1349,7 @@ void IpsDisplay::drawULCompass(){
 	}
 }
 
+// static int scy=0;
 
 void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, float polar_sink_ms, float altitude_m,
 		float temp, float volt, float s2fd_ms, float s2f_ms, float acl_ms, bool s2fmode, bool standard_setting, float wksensor ){
@@ -1532,7 +1363,6 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 	xSemaphoreTake(spiMutex,portMAX_DELAY );
 	// ESP_LOGI(FNAME,"drawRetroDisplay  TE=%0.1f IAS:%d km/h  WK=%d", te, airspeed, wksensor  );
 	// uncomment for scroll test
-	// static int scy=0;
 	// scy+=10;
 	// ucg->scrollLines( scy%320 );
 	bool netto=false;
@@ -1550,13 +1380,13 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 	if( !(tick%20) ){
 		if( netto != netto_old ){
 			ucg->setFont(ucg_font_fub11_hr);
-			ucg->setPrintPos(70,15);
+			ucg->setPrintPos(40,15);
 			if( netto )
-				ucg->setColor( COLOR_HEADER );
+				ucg->setColor( COLOR_WHITE );
 			else
 				ucg->setColor( COLOR_BLACK );
 			if( netto_mode.get() == NETTO_NORMAL )
-				ucg->print( "net  " );
+				ucg->print( "  net" );
 			else
 				ucg->print( "s-net" );
 			netto_old = netto;
@@ -1580,8 +1410,10 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 	// draw TE pointer
 	float a = (te)/(_range) * (M_PI_2);
 	if( int(a*100) != int(old_a*100) ) {
-		drawPolarIndicator( a, AMIDX, AMIDY, 75, 130, 2, COLOR_ORANGE );
+		drawTetragon( a, AMIDX, AMIDY, 60, 120, 3, COLOR_WHITE );
 		// ESP_LOGI(FNAME,"IpsDisplay::drawRetroDisplay  TE=%0.1f  x0:%d y0:%d x2:%d y2:%d", te, x0, y0, x2,y2 );
+		// Climb bar
+
 	}
 	if( _menu ){
 		xSemaphoreGive(spiMutex);
@@ -1594,14 +1426,14 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 			if( te > te_prev && te > 0 ){  // draw green what's missing
 				for( float a=te_prev; a<te && a<_range; a+=step ) {
 					if( a >= step*2 ) // don't overwrite the '0'
-						drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 135, 140, 2, COLOR_GREEN, false );
+						drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_GREEN, false );
 				}
 			}
 			else{   // delete what's too much
 				ESP_LOGD(FNAME,"delete te:%0.2f prev:%0.2f", te, te_prev );
 				for( float a=te_prev+step; a>=te && a >= step; a-=step ) {
 					ESP_LOGD(FNAME,"delete %0.2f", a );
-					drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 134, 141, 2, COLOR_BLACK, false );
+					drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
 				}
 			}
 			te_prev = te+step;
@@ -1620,26 +1452,26 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 						ESP_LOGD(FNAME,"blue a=%f",a);
 						if( a <= -step*2 ){ // don't overwrite the '0'
 							if( netto )
-								drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 135, 140, 2, COLOR_RED, false );
+								drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_RED, false );
 							else
-								drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 135, 140, 2, COLOR_BLUE, false );
+								drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_BLUE, false );
 						}
 					}
 				}
 				else{   // delete what's too much
 					for( float a=polar_sink_prev-step; a<=val && a <= -step; a+=step ) {
 						ESP_LOGD(FNAME,"black a=%f",a);
-						drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 134, 141, 2, COLOR_BLACK, false );
+						drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
 					}
 				}
 				polar_sink_prev = val + step;
 			}
 		}
 	}
-
+	// vTaskDelay(3);
 	// average Climb
 	if( (int)(ate*30) != _ate && !(tick%3) ) {
-		drawAvgVario( AMIDX - 50, AMIDY+2, ate );
+		drawAvgVario( 90, AMIDY+2, ate );
 		_ate = (int)(ate*30);
 	}
 	// MC val
@@ -1653,25 +1485,93 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 	// Bluetooth
 	if( !(tick%12) )
 	{
-		drawConnection(DISPLAY_W-27, FLOGO+2 );
+		if( wireless == WL_BLUETOOTH )
+			drawBT();
+		else
+			drawWifi(DISPLAY_W-27, FLOGO+2 );
+		drawCAN(DISPLAY_W-32, FLOGO+28);
 	}
 
 	// S2F Command triangle
-	if( ((int)s2fd != s2fdalt && !((tick+1)%2) ) || !((tick+3)%30) ) {
-		drawS2FBar(AMIDX, AMIDY,(int)s2fd);
-	}
+	if( ((int)s2fd != s2fdalt && !((tick+1)%2) ) || !(tick+3%30) ) {
+		// ESP_LOGI(FNAME,"S2F in");
+		int start=120;
+		int width=50;
+		int maxs2f=55;
+		if( compass_enable.get() && compass_enable.get() )
+			maxs2f=35;
+		ucg->setClipRange( start, dmid-maxs2f-25, width, (maxs2f*2)+1+25 );
+		bool clear = false;
+		int dmo = dmid+25;
+		if( s2fd > 0 ) {
+			if ( (int)s2fd < s2fdalt || (int)s2fdalt < 0 ){
+				clear = true;
+			}
+		}
+		else {
+			if ( (int)s2fd > s2fdalt || (int)s2fdalt > 0  ) {
+				clear = true;
+			}
+		}
+		if( int(s2fd) < 0  && (int)s2fdalt < 0 )
+			dmo = dmid-25;
 
+		if( dmo < dmid )
+			ucg->setClipRange( start, dmid-25-maxs2f, width, (maxs2f)+1 );
+		else
+			ucg->setClipRange( start, dmid+25, width, (maxs2f)+1 );
+		// clear old triangle for S2F
+		if( clear ) {
+			ucg->setColor( COLOR_BLACK );
+			ucg->drawTriangle(  start, dmo,
+					start+(width/2), dmo+(int)s2fd,
+					start+(width/2), dmo+(int)s2fdalt );
+			ucg->drawTriangle( 	start+width, dmo,
+					start+(width/2), dmo+(int)s2fd,
+					start+(width/2), dmo+(int)s2fdalt );
+		}
+		// draw new S2F command triangle
+		if( s2fd < 0 )
+			ucg->setColor( LIGHT_GREEN );
+		else
+			ucg->setColor( COLOR_RED );
+		// ESP_LOGI(FNAME,"S2F %d-%d %d-%d %d-%d", start, dmid, start+width, dmid, start+(width/2), dmid+(int)s2fd );
+		ucg->drawTriangle(  start, dmo,
+				start+width, dmo,
+				start+(width/2), dmo+(int)s2fd );
+
+		ucg->undoClipRange();
+		if( s2fd > 0 && s2fdalt < 0 ){
+			ucg->setColor( COLOR_BLACK );
+			ucg->drawBox( start, dmid-25-maxs2f, width, (maxs2f)+1 );
+		}
+		else if( s2fd < 0 && s2fdalt > 0 ){
+			ucg->setColor( COLOR_BLACK );
+			ucg->drawBox( start, dmid+25, width, (maxs2f)+1 );
+		}
+		// every 10 km/h one line
+		if( s2fd > 0 ){
+			ucg->setColor( COLOR_BLACK );
+			for( int i=0; i<s2fd && i<maxs2f; i+=10 ) {
+				ucg->drawHLine( start, dmid+25+i, width );
+				ucg->drawHLine( start, dmid+25+i+1, width );
+			}
+		}else{
+			ucg->setColor( COLOR_BLACK );
+			for( int i=0; i>s2fd && i>-maxs2f; i-=10 ) {
+				ucg->drawHLine( start, dmid-25+i, width );
+				ucg->drawHLine( start, dmid-25+i-1, width );
+			}
+		}
+		s2fdalt=(int)s2fd;
+	}
 	if( _menu ){
 		xSemaphoreGive(spiMutex);
 		return;
 	}
-
-	// Altitude & Airspeed
-	if( !(tick%8) ) {
-		drawAltitude( altitude, 180, 250 );
-		if( as_prev != airspeed || !(tick%64) ) {
-			drawSpeed(airspeed, 180, 282);
-		}
+	// Altitude
+	if(!(tick%8) ) {
+		drawAltitude( altitude, 110,282 );
 	}
 
 	// Battery
@@ -1679,7 +1579,7 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 	if( volt < bat_red_volt.get() ){
 		if( !(tick%40) )
 			blank = true;
-		else if( !((tick+10)%20) )
+		else if( !((tick+20)%40) )
 			blank = false;
 	}
 	else
@@ -1692,30 +1592,30 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 
 	// Temperature Value
 	if( (int)(temp*10) != tempalt && !(tick%12)) {
-		drawTemperature( 5, 25, temp );
+		drawTemperature( 20, 38, temp );
 		tempalt=(int)(temp*10);
 	}
 
 	// WK-Indicator
 	if( FLAP && !(tick%7) )
 	{
-		float wkspeed = Units::ActualWingloadCorrection(airspeed_kmh);
+		float wkspeed = airspeed * sqrt( 100.0/( ballast.get() +100.0) );
 		int wki;
 		float wkopt = FLAP->getOptimum( wkspeed, wki );
 		int wk = (int)((wki - wkopt + 0.5)*10);
-		// ESP_LOGI(FNAME,"as:%d wksp:%f wki:%d wk:%d wkpos:%f", airspeed_kmh, wkspeed, wki, wk, wkpos );
+		// ESP_LOGI(FNAME,"as:%d wksp:%f wki:%d wk:%d wkpos:%f", airspeed, wkspeed, wki, wk, wkpos );
 		// ESP_LOGI(FNAME,"WK changed WKE=%d WKS=%f", wk, wksensor );
 		ucg->setColor(  COLOR_WHITE  );
 		FLAP->drawBigBar( WKBARMID, WKSYMST-4, (float)(wk)/10, wksensor );
 		wkoptalt = wk;
 		wksensoralt = (int)(wksensor*10);
 
-		// FLAP->drawWingSymbol( WKBARMID-27*(abs(flap_neg_max.get()))-18, WKSYMST-3, wki, wksensor);
+		FLAP->drawWingSymbol( WKBARMID-(27*(abs(flap_neg_max.get())+1) ), WKSYMST-3, wki, wksensor);
 	}
 
 	// Cruise mode or circling
 	if( (int)s2fmode != s2fmode_prev ){
-		drawS2FMode( 17, 272, s2fmode );
+		drawS2FMode( 180, 20, s2fmode );
 		s2fmode_prev = (int)s2fmode;
 	}
 
@@ -1725,6 +1625,23 @@ void IpsDisplay::drawRetroDisplay( int airspeed_kmh, float te_ms, float ate_ms, 
 		drawAvg( acl, acl-average_climbf );
 		average_climb = (int)(acl*10);
 		average_climbf = acl;
+	}
+	// Airspeed
+	if( !(tick%7) ){
+		if( as_prev != airspeed || !(tick%70) ) {
+			// ESP_LOGI(FNAME,"draw airspeed %d %d", airspeed, as_prev );
+			ucg->setColor(  COLOR_WHITE  );
+			ucg->setPrintPos(113,73);
+			ucg->setFont(ucg_font_fub20_hr);
+			char s[10];
+			sprintf(s,"%3d",  airspeed );
+			int fl=ucg->getStrWidth(s);
+			ucg->printf("%s  ", s);
+			ucg->setPrintPos(113+fl,70);
+			ucg->setFont(ucg_font_fub11_hr);
+			ucg->printf(" %s  ", Units::AirspeedUnit() );
+			as_prev = airspeed;
+		}
 	}
 	// Compass
 	if( !(tick%8) ){
@@ -1788,7 +1705,7 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	// draw TE pointer
 	float a = (te)/(_range) * (M_PI_2);
 	if( int(a*100) != int(old_a*100) ) {
-		drawPolarIndicator( a, AMIDX, AMIDY, 60, 120, 3, COLOR_RED );
+		drawTetragon( a, AMIDX, AMIDY, 60, 120, 3, COLOR_RED );
 		// ESP_LOGI(FNAME,"IpsDisplay::drawULDisplay  TE=%0.1f  x0:%d y0:%d x2:%d y2:%d", te, x0, y0, x2,y2 );
 		// Climb bar
 
@@ -1800,14 +1717,14 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 			if( te > te_prev && te > 0 ){  // draw green what's missing
 				for( float a=te_prev; a<te && a<_range; a+=step ) {
 					if( a >= step*2 ) // don't overwrite the '0'
-						drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_GREEN, false );
+						drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_GREEN, false );
 				}
 			}
 			else{   // delete what's too much
 				ESP_LOGD(FNAME,"delete te:%0.2f prev:%0.2f", te, te_prev );
 				for( float a=te_prev+step; a>=te && a >= step; a-=step ) {
 					ESP_LOGD(FNAME,"delete %0.2f", a );
-					drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
+					drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
 				}
 			}
 			te_prev = te+step;
@@ -1830,16 +1747,16 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 						ESP_LOGD(FNAME,"blue a=%f",a);
 						if( a <= -step*2 ){ // don't overwrite the '0'
 							if( netto )
-								drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_RED, false );
+								drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_RED, false );
 							else
-								drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_BLUE, false );
+								drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 120, 125, 2, COLOR_BLUE, false );
 						}
 					}
 				}
 				else{   // delete what's too much
 					for( float a=polar_sink_prev-step; a<=val && a <= -step; a+=step ) {
 						ESP_LOGD(FNAME,"black a=%f",a);
-						drawPolarIndicator( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
+						drawTetragon( ((float)a/_range)*M_PI_2, AMIDX, AMIDY, 119, 126, 2, COLOR_BLACK, false );
 					}
 				}
 				polar_sink_prev = val + step;
@@ -1854,7 +1771,10 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	// Bluetooth
 	if( !(tick%12) )
 	{
-		drawConnection(DISPLAY_W-27, FLOGO+2 );
+		if( wireless == WL_BLUETOOTH )
+			drawBT();
+		else
+			drawWifi(DISPLAY_W-27, FLOGO+2 );
 	}
 
 	// Altitude Header
@@ -1866,12 +1786,13 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 		// redraw just in case the vario pointer was there
 		if( qnh != pref_qnh ) {
 			ucg->setFont(ucg_font_fub11_tr);
+			ucg->setPrintPos(FIELD_START,YALT-S2FFONTH-10);
 			char unit[4];
 			if( standard_setting )
 				sprintf( unit, "QNE" );
 			else
 				sprintf( unit, "QNH" );
-			ucg->setPrintPos(FIELD_START_UL-50,(YALT-S2FFONTH-10));
+			ucg->setPrintPos(FIELD_START,(YALT-S2FFONTH-10));
 			ucg->setColor(0, COLOR_HEADER );
 			ucg->printf("%s %.2f %s   ", unit, qnh, Units::QnhUnit( qnh_unit.get() ) );
 			pref_qnh = qnh;
@@ -1883,7 +1804,7 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	}
 	// Altitude
 	if(!(tick%8) ) {
-		drawAltitude( altitude, FIELD_START_UL, YALT-4 );
+		drawAltitude( altitude, 113,YALT-4 );
 	}
 
 	// Battery
@@ -1891,7 +1812,7 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	if( volt < bat_red_volt.get() ){
 		if( !(tick%40) )
 			blank = true;
-		else if( !((tick+10)%20) )
+		else if( !((tick+20)%40) )
 			blank = false;
 	}
 	else
@@ -1904,14 +1825,14 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 
 	// Temperature Value
 	if( (int)(temp*10) != tempalt && !(tick%12)) {
-		drawTemperature( 20, 30, temp );
+		drawTemperature( 20, 38, temp );
 		tempalt=(int)(temp*10);
 	}
 
 	// WK-Indicator
 	if( FLAP && !(tick%7) )
 	{
-		float wkspeed = Units::ActualWingloadCorrection(airspeed_kmh);
+		float wkspeed = airspeed * sqrt( 100.0/( ballast.get() +100.0) );
 		int wki;
 		float wkopt=FLAP->getOptimum( wkspeed, wki );
 		int wk = (int)((wki - wkopt + 0.5)*10);
@@ -1922,7 +1843,7 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 		wkoptalt = wk;
 		wksensoralt = (int)(wksensor*10);
 
-		FLAP->drawWingSymbol( WKBARMID-27*(abs(flap_neg_max.get()))-18, WKSYMST-3, wki, wksensor);
+		FLAP->drawWingSymbol( WKBARMID-(27*(abs(flap_neg_max.get())+1) ), WKSYMST-3, wki, wksensor);
 	}
 
 	// Medium Climb Indicator
@@ -1935,7 +1856,18 @@ void IpsDisplay::drawULDisplay( int airspeed_kmh, float te_ms, float ate_ms, flo
 	// Airspeed
 	if( !(tick%7) ){
 		if( as_prev != airspeed || !(tick%49) ) {
-			drawSpeed(airspeed, FIELD_START_UL, 73);
+			ucg->setColor(  COLOR_WHITE  );
+			ucg->setPrintPos(113,73);
+			ucg->setFont(ucg_font_fub25_hr);
+			char s[10];
+			sprintf(s,"%3d",  airspeed );
+			int fl=ucg->getStrWidth(s);
+			ucg->printf("%s  ", s);
+			ucg->setPrintPos(113+fl,70);
+			ucg->setFont(ucg_font_fub20_hr);
+			ucg->printf(" %s  ", Units::AirspeedUnit() );
+			as_prev = airspeed;
+
 		}
 	}
 	// Compass
@@ -2028,7 +1960,7 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 	// WK-Indicator
 	if( FLAP && !(tick%7) )
 	{
-		float wkspeed = Units::ActualWingloadCorrection(airspeed_kmh);
+		float wkspeed = airspeed * sqrt( 100.0/( ballast.get() +100.0) );
 		int wki;
 		float wkopt=FLAP->getOptimum( wkspeed, wki );
 		int wk = (int)((wki - wkopt + 0.5)*10);
@@ -2081,7 +2013,7 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 
 	// Altitude
 	if(!(tick%8) ) {
-		drawAltitude( altitude, FIELD_START+80, YALT+6 );
+		drawAltitude( altitude, FIELD_START,YALT+6 );
 	}
 	// MC Value
 	if(  !(tick%8) ) {
@@ -2098,7 +2030,7 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 	}
 	// Temperature Value
 	if( (int)(temp*10) != tempalt && !(tick%11)) {
-		drawTemperature( FIELD_START+20, DISPLAY_H-6, temp );
+		drawTemperature( FIELD_START+30, DISPLAY_H, temp );
 		tempalt=(int)(temp*10);
 	}
 	// Battery Symbol
@@ -2113,7 +2045,7 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 	else
 		blank = false;
 	if ( chargealt != chargev || blank != blankold ) {
-		drawBat( volt, BATX, BATY, blank );
+		drawBat( volt, BATX, BATY+3, blank );
 		chargealt = chargev;
 		blankold = blank;
 	}
@@ -2121,7 +2053,10 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 	// Bluetooth Symbol
 
 	if( !(tick%12) ){
-		drawConnection(DISPLAY_W-27, FLOGO);
+		if( wireless == WL_BLUETOOTH )
+			drawBT();
+		else
+			drawWifi(DISPLAY_W-25, FLOGO);
 	}
 
 	bool flarm=false;
@@ -2246,7 +2181,10 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 		}
 		ucg->undoClipRange();
 		// AS cleartext
-		drawSpeed(airspeed, FIELD_START+35, YS2F-fh+3, false);
+		ucg->setFont(ucg_font_fub14_hn);
+		ucg->setPrintPos(FIELD_START+8, YS2F-fh-3 );
+		ucg->setColor(  COLOR_WHITE  );
+		ucg->printf("%3d ", airspeed );
 		as_prev = airspeed;
 	}
 	// S2F command trend triangle
@@ -2264,12 +2202,71 @@ void IpsDisplay::drawAirlinerDisplay( int airspeed_kmh, float te_ms, float ate_m
 			ucg->setColor(  COLOR_WHITE  );
 		}
 		// S2F value
-		drawSpeed((int)(s2f+0.5), ASVALX+30, YS2F-fh+3, false);
-
+		ucg->setColor(  COLOR_WHITE  );
+		ucg->setFont(ucg_font_fub14_hn);
+		int fa=ucg->getFontAscent();
+		int fl=ucg->getStrWidth("100");
+		ucg->setPrintPos(ASVALX, YS2F-fh-3);
+		ucg->printf("%3d  ", (int)(s2falt+0.5)  );
 		// draw S2F Delta
-		drawSpeed((int)(s2fd+0.5), ASVALX+30, DISPLAY_H/2+fh+3, false);
-		drawS2FBar(ASVALX+20, DISPLAY_H/2, s2fd);
+		// erase old
+		ucg->setColor(  COLOR_BLACK  );
+		char s[10];
+		sprintf(s,"%+3d  ",(int)(s2fdalt+0.5));
+		fl=ucg->getStrWidth(s);
+		ucg->setPrintPos( FIELD_START+S2FST+(S2F_TRISIZE/2)-fl/2-5,yposalt );
+		ucg->printf(s);
+		int ypos;
+		if( s2fd < 0 )
+			ypos = dmid+s2fclip-2;  // slower, up
+		else
+			ypos = dmid+s2fclip+12+fa;
+		// new S2F Delta val
+		if( abs(s2fd) > 10 ) {
+			ucg->setColor(  COLOR_WHITE  );
+			sprintf(s," %+3d  ",(int)(s2fd+0.5));
+			fl=ucg->getStrWidth(s);
+			ucg->setPrintPos( FIELD_START+S2FST+(S2F_TRISIZE/2)-fl/2,ypos );
+			ucg->printf(s);
+		}
+		yposalt = ypos;
+		ucg->setClipRange( FIELD_START+S2FST, dmid-MAXS2FTRI, S2F_TRISIZE, (MAXS2FTRI*2)+1 );
+		bool clear = false;
+		if( s2fd > 0 ) {
+			if ( (int)s2fd < s2fdalt || (int)s2fdalt < 0 )
+				clear = true;
+		}
+		else {
+			if ( (int)s2fd > s2fdalt || (int)s2fdalt > 0  )
+				clear = true;
+		}
+		// clear old triangle for S2F
+		if( clear ) {
+			ucg->setColor( COLOR_BLACK );
+			ucg->drawTriangle( FIELD_START+S2FST, dmid,
+					FIELD_START+S2FST+(S2F_TRISIZE/2), dmid+(int)s2fd,
+					FIELD_START+S2FST+(S2F_TRISIZE/2), dmid+(int)s2fdalt );
+			ucg->drawTriangle( FIELD_START+S2FST+S2F_TRISIZE, dmid,
+					FIELD_START+S2FST+(S2F_TRISIZE/2), dmid+(int)s2fd,
+					FIELD_START+S2FST+(S2F_TRISIZE/2), dmid+(int)s2fdalt );
+		}
+		// draw new S2F command triangle
+		if( s2fd < 0 )
+			ucg->setColor( LIGHT_GREEN );
+		else
+			ucg->setColor( COLOR_RED );
+		ucg->drawTriangle( FIELD_START+S2FST, dmid,
+				FIELD_START+S2FST+S2F_TRISIZE, dmid,
+				FIELD_START+S2FST+(S2F_TRISIZE/2), dmid+(int)s2fd );
 
+		ucg->undoClipRange();
+		// green bar for optimum speed within tacho
+		ucg->setClipRange( FIELD_START, dmid-(MAXS2FTRI), ASLEN+6, (MAXS2FTRI*2) );
+		ucg->setColor( COLOR_BLACK );
+		ucg->drawBox( FIELD_START+1,dmid+s2fdalt-16, 6, 32 );
+		ucg->setColor( COLOR_GREEN );
+		ucg->drawBox( FIELD_START+1,dmid+s2fd-15, 6, 30 );
+		ucg->undoClipRange();
 		s2fdalt = (int)s2fd;
 		s2falt = (int)(s2f+0.5);
 		s2fclipalt = s2fdalt;

--- a/main/IpsDisplay.h
+++ b/main/IpsDisplay.h
@@ -68,7 +68,7 @@ private:
 	static int _ate;
 	static int s2falt;
 	static int s2fdalt;
-	static int alt_prev;
+	static int prefalt;
 	static float pref_qnh;
 	static int chargealt;
 	static int btqueue;
@@ -82,7 +82,7 @@ private:
 	static int wkalt;
 	static int wkoptalt;
 	static int wksensoralt;
-
+	
 	static int yposalt;
 	static int tyalt;
 	static int pyalt;
@@ -94,41 +94,44 @@ private:
 	static int yellow;
 	static ucg_color_t wkcolor;
 	static bool netto_old;
-	static ucg_int_t char_width;
 
 	// Pointer edges and alpha for analog display
 	static float old_a;
+	static int x_0;
+	static int y_0;
+	static int x_1;
+	static int y_1;
+	static int x_2;
+	static int y_2;
+	static int x_3;
+	static int y_3;
 
 	static void drawMC( float mc, bool large=false );
 	static void drawS2FMode( int x, int y, bool cruise );
-	static void drawArrow(int x, int y, int level, bool del);
-	static void drawS2FBar(int x, int y, int s2fd);
 	static void drawCircling( int x, int y, bool draw );
 	static void drawCruise( int x, int y, bool draw );
 	static void drawBT();
-	static void drawCable(int x, int y);
 	static void drawFlarm( int x, int y, bool flarm );
 	static void drawWifi( int x, int y );
-	static void drawConnection( int x, int y );
+	static void drawCAN( int x, int y );
 	static void drawBat( float volt, int x, int y, bool blank );
 	static void drawTemperature( int x, int y, float t );
 	static void drawThermometer( int x, int y );
-	static void drawPolarIndicator( float a, int x0, int y0, int l1, int l2, int w, int r, int g, int b, bool del=true );
+	static void drawTetragon( float a, int x0, int y0, int l1, int l2, int w, int r, int g, int b, bool del=true );
 	static void initRetroDisplay();
 	static void initULDisplay();
 	static void initLoadDisplay();
 	static void drawRetroDisplay( int airspeed, float te, float ate, float polar_sink, float alt, float temperature, float volt, float s2fd, float s2f, float acl, bool s2fmode, bool standard_alt, float wksensor );
 	static void drawULDisplay( int airspeed, float te, float ate, float polar_sink, float alt, float temperature, float volt, float s2fd, float s2f, float acl, bool s2fmode, bool standard_alt, float wksensor );
 	static void drawAirlinerDisplay( int airspeed, float te, float ate, float polar_sink, float alt, float temperature, float volt, float s2fd, float s2f, float acl, bool s2fmode, bool standard_alt, float wksensor );
-	static void annotateScale( int val, int pos, float range, int offset=0);
+	static void drawAnalogScale( int val, int pos, float range, int offset=0 );
 	static void drawScaleLines( bool full, float max_pos, float max_neg );
 	static void setTeBuf( int y1, int y2, int r, int g, int b );
 	static void drawTeBuf();
 	static void drawGaugeTriangle( int y, int r, int g, int b, bool s2f=false );
 	static void drawAvgSymbol( int y, int r, int g, int b, int x=DISPLAY_LEFT );
 	static void drawAvg( float mps, float delta );
-	static void drawAltitude( float altitude, ucg_int_t x, ucg_int_t y, bool inc_unit = true );
-	static void drawSpeed(int speed, ucg_int_t x, ucg_int_t y, bool inc_unit=true);
+	static void drawAltitude( float altitude, int x, int y );
 	static void drawLegend( bool onlyLines=false );
 	static void drawAvgVario( int x, int y, float ate );
 

--- a/main/Router.cpp
+++ b/main/Router.cpp
@@ -155,9 +155,9 @@ void Router::routeS1(){
 		if( serial1_rxloop.get() )  // only 0=DISABLE | 1=ENABLE
 			if( forwardMsg( s1, s1_tx_q ))
 				ESP_LOGV(FNAME,"ttyS1 RX bytes %d looped to s1_tx_q", s1.length() );
-		if( (can_tx.get() & RT_XCVARIO) && can_speed.get() )
+		if( (serial1_tx.get() & RT_XCVARIO) && can_speed.get() )
 			if( forwardMsg( s1, client_tx_q ))
-				ESP_LOGV(FNAME,"ttyS1 RX bytes %d forward to client_tx_q", s1.length() );
+				ESP_LOGV(FNAME,"ttyS2 RX bytes %d forward to client_tx_q", s2.length() );
         if( (serial2_tx.get() & RT_S1) && serial2_speed.get() )
 			if( forwardMsg( s1, s2_tx_q ))
 				ESP_LOGV(FNAME,"ttyS1 RX bytes %d looped to s2_tx_q", s1.length() );
@@ -177,12 +177,12 @@ void Router::routeS2(){
 		if( wireless == WL_BLUETOOTH )
 			if( forwardMsg( s2, bt_tx_q ))
 				ESP_LOGV(FNAME,"ttyS2 RX bytes %d forward to bt_tx_q", s2.length() );
-		if( (can_tx.get() & RT_XCVARIO) && can_speed.get() )
+		if( (serial2_tx.get() & RT_XCVARIO) && can_speed.get() )
 			if( forwardMsg( s2, client_tx_q ))
-				ESP_LOGV(FNAME,"ttyS2 RX bytes %d forward to client_tx_q", s2.length() );
-		// if( (serial1_tx.get() & RT_S2) && serial1_speed.get() )
-		// 	if( forwardMsg( s2, s1_tx_q ))
-		// 		ESP_LOGV(FNAME,"ttyS2 RX bytes %d looped to s1_tx_q", s2.length() );
+				ESP_LOGI(FNAME,"ttyS2 RX bytes %d forward to client_tx_q", s2.length() );
+		if( (serial2_tx.get() & RT_S1) && serial1_speed.get() )
+			if( forwardMsg( s2, s1_tx_q ))
+				ESP_LOGV(FNAME,"ttyS2 RX bytes %d looped to s1_tx_q", s2.length() );
 		Protocols::parseNMEA( s2.c_str() );
 	}
 }
@@ -248,7 +248,7 @@ void Router::routeBT(){
 	}
 }
 
-// route messages from master or client via CAN or Wifi
+// route messages from CAN
 void Router::routeClient(){
 	SString client;
 	if( pullMsg( client_rx_q, client ) ){
@@ -256,17 +256,17 @@ void Router::routeClient(){
         if ( strncmp( client.c_str(), "!xs", 3 ) != 0 ) {
             if( (serial1_tx.get() & RT_XCVARIO) && serial1_speed.get() ) {
                 if( forwardMsg( client, s1_tx_q ) ) {
-                    ESP_LOGV(FNAME,"Send to S1 device, client link received %d bytes NMEA", client.length() );
+                    ESP_LOGV(FNAME,"Send to S1 device, CAN received %d bytes", client.length() );
                 }
             }
             if( (serial2_tx.get() & RT_XCVARIO) && serial2_speed.get() ) {
                 if( forwardMsg( client, s2_tx_q ) ) {
-                    ESP_LOGI(FNAME,"Send to S2 device, client link received %d bytes NMEA", client.length() );
+                    ESP_LOGV(FNAME,"Send to S2 device, CAN received %d bytes", client.length() );
                 }
             }
     		if( wireless == WL_BLUETOOTH )
     			if( forwardMsg( client, bt_tx_q )){
-    				ESP_LOGI(FNAME,"Send to BT device, client link received %d bytes NMEA", client.length() );
+    				ESP_LOGI(FNAME,"Route Client link received NMEA to bt_tx_q %d bytes", client.length() );
     			}
         }
 		Protocols::parseNMEA( client.c_str() );

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -1522,13 +1522,10 @@ void SetupMenu::setup( )
 
 		SetupMenuSelect * canrt = new SetupMenuSelect( PROGMEM "Routing", false , 0, false, &can_tx );
 		can->addEntry( canrt );
-		canrt->setHelp( PROGMEM "Select data source that is routed to the CAN interface", 230);
+		canrt->setHelp( PROGMEM "Select data source that is routed from/to CAN interface");
 		canrt->addEntry( "Disable");
 		canrt->addEntry( "XCVario");
-        canrt->addEntry( "tbd.");    // 2 not yet used
-        canrt->addEntry( "tbd.");     // 3
-		canrt->addEntry( "S1");                 // 4 route Flarm on S1 to client
-        canrt->addEntry( "XCVario, S1");        // 5
+
 
 		SetupMenuSelect * devmod = new SetupMenuSelect( PROGMEM "Mode", true , 0, false, &can_mode );
 		can->addEntry( devmod );

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -167,10 +167,10 @@ SetupNG<float>  		flap_minus_1( "FLAP_MINUS_1", 105,  true, SYNC_FROM_MASTER, PE
 SetupNG<float>  		flap_0( "FLAP_0", 88,  true, SYNC_FROM_MASTER, PERSISTENT, flap_act);
 SetupNG<float>  		flap_plus_1( "FLAP_PLUS_1", 78,  true, SYNC_FROM_MASTER, PERSISTENT, flap_act);
 SetupNG<float>  		flap_plus_2( "FLAP_PLUS_2", 70,  true, SYNC_FROM_MASTER, PERSISTENT, flap_act);
-SetupNG<int>  			alt_unit( "ALT_UNIT", ALT_UNIT_METER );
-SetupNG<int>  			ias_unit( "IAS_UNIT", SPEED_UNIT_KMH );
-SetupNG<int>  			vario_unit( "VARIO_UNIT", VARIO_UNIT_MS );
-SetupNG<int>  			temperature_unit( "TEMP_UNIT", T_CELCIUS );
+SetupNG<int>  			alt_unit( "ALT_UNIT", ALT_UNIT_METER, true, SYNC_FROM_MASTER );
+SetupNG<int>  			ias_unit( "IAS_UNIT", SPEED_UNIT_KMH, true, SYNC_FROM_MASTER );
+SetupNG<int>  			vario_unit( "VARIO_UNIT", VARIO_UNIT_MS, true, SYNC_FROM_MASTER );
+SetupNG<int>  			temperature_unit( "TEMP_UNIT", T_CELCIUS, true, SYNC_FROM_MASTER );
 SetupNG<int>  			qnh_unit("QNH_UNIT", QNH_HPA, true, SYNC_FROM_MASTER );
 SetupNG<int>  			rot_default( "ROTARY_DEFAULT", 0 );
 SetupNG<int>  			serial1_speed( "SERIAL2_SPEED", 3 );   // tag will stay SERIAL2 from historical reason
@@ -447,10 +447,6 @@ bool SetupCommon::haveWLAN(){
 
 bool SetupCommon::isClient(){
 	return((wireless == WL_WLAN_CLIENT) || (can_speed.get() != CAN_SPEED_OFF && can_mode.get() == CAN_MODE_CLIENT));
-}
-
-bool SetupCommon::isWired(){
-	return(can_speed.get() && (can_mode.get() == CAN_MODE_CLIENT || can_mode.get() == CAN_MODE_MASTER));
 }
 
 bool SetupCommon::commitNow()

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -108,7 +108,6 @@ public:
 	static bool factoryReset();
 	static bool isMaster();
 	static bool isClient();
-    static bool isWired();
 	static bool haveWLAN();
     static bool lazyCommit;
     static bool commitNow();

--- a/main/Units.h
+++ b/main/Units.h
@@ -6,7 +6,7 @@
 
 class Units {
 public:
-	static float Airspeed( float as ){
+	static inline float Airspeed( float as ){
 		if( ias_unit.get() == SPEED_UNIT_KMH ) // km/h
 			return( as );
 		else if( ias_unit.get() == SPEED_UNIT_MPH ) // mph
@@ -18,36 +18,23 @@ public:
 		return 0;
 	};
 
-	static int AirspeedRounded( float as ){
-        float ret = 0;
-		if( ias_unit.get() == SPEED_UNIT_KMH ) { // km/h
-			ret = as; }
-		else if( ias_unit.get() == SPEED_UNIT_MPH ) { // mph
-			ret = as*0.621371; }
-		else if( ias_unit.get() == SPEED_UNIT_KNOTS ) { // knots
-			ret = as*0.539957; }
-		else {
-			ESP_LOGE(FNAME,"Wrong unit for AS"); }
-		return (int)roundf(ret);
-	};
-
-	static float kmh2knots( float kmh ){
+	static inline float kmh2knots( float kmh ){
 			return( kmh / 1.852 );
 	};
 
-	static float kmh2ms( float kmh ){
+	static inline float kmh2ms( float kmh ){
 			return( kmh * 0.277778 );
 	};
 
-	static float ms2kmh( float ms ){
+	static inline float ms2kmh( float ms ){
 			return( ms * 3.6 );
 	};
 
-	static float knots2kmh( float knots ){
+	static inline float knots2kmh( float knots ){
 				return( knots * 1.852 );
 	};
 
-	static float Airspeed2Kmh( float as ){
+	static inline float Airspeed2Kmh( float as ){
 		if( ias_unit.get() == SPEED_UNIT_KMH ) // km/h
 			return( as );
 		else if( ias_unit.get() == SPEED_UNIT_MPH ) // mph
@@ -59,11 +46,7 @@ public:
 		return 0;
 	};
 
-    static float ActualWingloadCorrection( float v ) {
-        return v * sqrt( 100.0/( ballast.get() + 100.0) );
-    }
-
-	static float TemperatureUnit( float t ){
+	static inline float TemperatureUnit( float t ){
 		if( temperature_unit.get() == T_CELCIUS ) // °C
 			return( t );
 		if( temperature_unit.get() == T_FAHRENHEIT ) // °C
@@ -75,7 +58,7 @@ public:
 		}
 	}
 
-	static const char * AirspeedUnit( int unit = -1 ){
+	static inline const char * AirspeedUnit( int unit = -1 ){
 		int u = unit;
 		if( u == -1 )
 			u=ias_unit.get();
@@ -90,7 +73,7 @@ public:
 		return "nan";
 	};
 
-	static float Vario( float te ){   // standard is m/s
+	static inline float Vario( float te ){   // standard is m/s
 		if( vario_unit.get() == VARIO_UNIT_MS )
 			return( te );
 		else if(  vario_unit.get() == VARIO_UNIT_FPM )
@@ -102,7 +85,7 @@ public:
 		return 0;
 	};
 
-	static float Qnh( float qnh ){   // standard is m/s
+	static inline float Qnh( float qnh ){   // standard is m/s
 		if( qnh_unit.get() == QNH_HPA )
 			return( qnh );
 		else if(  qnh_unit.get() == QNH_INHG )
@@ -112,7 +95,7 @@ public:
 		return 0;
 	};
 
-	static float QnhRaw( float qnh ){   // standard is m/s
+	static inline float QnhRaw( float qnh ){   // standard is m/s
 		if( qnh_unit.get() == QNH_HPA )
 			return( qnh );
 		else if(  qnh_unit.get() == QNH_INHG )
@@ -122,7 +105,7 @@ public:
 		return 0;
 	};
 
-	static void recalculateQnh(){
+	static inline void recalculateQnh(){
 		ESP_LOGI(FNAME,"recalculateQnh");
 		if( qnh_unit.get() == QNH_HPA ){
 			if( QNH.get() < 500 ){  // convert to hPa
@@ -138,22 +121,22 @@ public:
 		}
 	}
 
-	static float hPa2inHg( float hpa ){   // standard is m/s
+	static inline float hPa2inHg( float hpa ){   // standard is m/s
 		return( hpa * 0.02952998597817832 );
 	};
-	static float inHg2hPa( float inhg ){   // standard is m/s
+	static inline float inHg2hPa( float inhg ){   // standard is m/s
 		return( inhg / 0.02952998597817832 );
 	};
 
-	static float knots2ms( float knots ){   // if we got it in knots
+	static inline float knots2ms( float knots ){   // if we got it in knots
 			return( knots/1.94384 );
 	};
 
-	static float ms2knots( float knots ){   // if we got it in knots
+	static inline float ms2knots( float knots ){   // if we got it in knots
 			return( knots*1.94384 );
 	};
 
-	static float Vario2ms( float var ){
+	static inline float Vario2ms( float var ){
 		if( vario_unit.get() == VARIO_UNIT_MS )
 			return( var );
 		else if(  vario_unit.get() == VARIO_UNIT_FPM )
@@ -165,7 +148,7 @@ public:
 		return 0;
 	};
 
-	static float mcval2knots( float mc ){   // returns MC, stored according to vario setting, in knots
+	static inline float mcval2knots( float mc ){   // returns MC, stored according to vario setting, in knots
 		if( vario_unit.get() == VARIO_UNIT_MS )             // mc is in m/s
 			return( mc*1.94384 );
 		else if(  vario_unit.get() == VARIO_UNIT_FPM )       // mc is stored in feet per minute
@@ -178,7 +161,7 @@ public:
 	};
 
 
-	static const char * VarioUnit(){
+	static inline const char * VarioUnit(){
 		if( vario_unit.get() == VARIO_UNIT_MS )
 			return("m/s");
 		else if( vario_unit.get() == VARIO_UNIT_FPM )
@@ -190,7 +173,7 @@ public:
 		return "nan";
 	};
 
-	static const char * QnhUnit( int unit ){
+	static inline const char * QnhUnit( int unit ){
 		if( unit == QNH_HPA )
 			return("hPa");
 		else if( unit == QNH_INHG )
@@ -201,7 +184,7 @@ public:
 	};
 
 
-	static const char * VarioUnitLong( int unit = -1 ){
+	static inline const char * VarioUnitLong( int unit = -1 ){
 		int u = unit;
 		if( u == -1 )
 			u=vario_unit.get();
@@ -216,7 +199,7 @@ public:
 		return "nan";
 	};
 
-	static float Altitude( float alt ){
+	static inline float Altitude( float alt ){
 		if( alt_unit.get() == 0 )  //m
 			return( alt );
 		else if( alt_unit.get() == 1 ) //feet
@@ -228,15 +211,15 @@ public:
 		return 0;
 	};
 
-	static float meters2feet( float m ){
+	static inline float meters2feet( float m ){
 			return( m*3.28084 );
 	};
 
-	static float feet2meters( float f ){
+	static inline float feet2meters( float f ){
 			return( f/3.28084 );
 	};
 
-	static const char * AltitudeUnit(){
+	static inline const char * AltitudeUnit(){
 		if( alt_unit.get() == 0 )  //m
 			return( "m" );
 		else if( alt_unit.get() == 1 ) //feet

--- a/main/sensor.cpp
+++ b/main/sensor.cpp
@@ -149,7 +149,7 @@ static float battery=0.0;
 static float dynamicP; // Pitot
 
 // global color variables for adaptable display variant
-int g_col_background=255; // black
+int g_col_background=255;
 int g_col_highlight=0;
 int g_col_header_r=101+g_col_background/5;
 int g_col_header_g=108+g_col_background/5;


### PR DESCRIPTION
Reverts iltis42/XCVario#71
Cannot takeover the whole changeset, as of some issues needed to be reworked.
- Polar Pointer gets clipped at the tip and color should be configurable
- Altimeter too small, and too close to airspeed, and airspeed should stay on top, or configurable
- Color of battery value not in azure grey just unit
- Flap symbol missing, should be visible at least for two negative flap settings
- Unclear issue with S2F toggling (might be unrelated)

Okay is: 
- Temperature Symbol
- Relocation of m/s
- Smaller S2F icon and relocation
- Rolling altitude concept 
- Sorted CAN routing option
- Individual Units on client
- 15 pixel increased display

To be discussed:
- Size of Altimeter
- Hard relocation of Airspeed
- Hard orange color for pointer and S2F indicator (less contrast)
- Hard removal of graphic Flap symbol

Proposal: Make two pull request and a review of the issues to be discussed

