### PR TITLE
Fix CMake warnings

### DIFF
--- a/components/I2Cbus/Kconfig
+++ b/components/I2Cbus/Kconfig
@@ -15,19 +15,20 @@ config I2CBUS_LOG_READWRITES
         Log all successuful read/write data, including port, slave address, 
         target register and the data written to. Useful for debugging.
 
-choice
-    prompt "Log level"
+choice I2CBUS_LOG_RW_LEVEL
+    bool "Log level"
     depends on I2CBUS_LOG_READWRITES
     default I2CBUS_LOG_RW_LEVEL_VERBOSE
     help
         Log level for successuful read/write operations. Levels depends on LOG_DEFAULT_LEVEL
-        
+
     config I2CBUS_LOG_RW_LEVEL_INFO
-    	bool "Info"
-	config I2CBUS_LOG_RW_LEVEL_DEBUG
-    	bool "Debug"
-	config I2CBUS_LOG_RW_LEVEL_VERBOSE
-    	bool "Verbose"
+        bool "Info"
+    config I2CBUS_LOG_RW_LEVEL_DEBUG
+        bool "Debug"
+    config I2CBUS_LOG_RW_LEVEL_VERBOSE
+        bool "Verbose"
+
 endchoice
 
 endmenu

--- a/components/I2Cbus/Kconfig.projbuild
+++ b/components/I2Cbus/Kconfig.projbuild
@@ -16,12 +16,12 @@ config I2CBUS_LOG_READWRITES
         target register and the data written to. Useful for debugging.
 
 choice I2CBUS_LOG_RW_LEVEL
-    prompt "Log level"
+    bool "Log level"
     depends on I2CBUS_LOG_READWRITES
     default I2CBUS_LOG_RW_LEVEL_VERBOSE
     help
         Log level for successuful read/write operations. Levels depends on LOG_DEFAULT_LEVEL
-        
+
     config I2CBUS_LOG_RW_LEVEL_INFO
         bool "Info"
     config I2CBUS_LOG_RW_LEVEL_DEBUG
@@ -30,6 +30,5 @@ choice I2CBUS_LOG_RW_LEVEL
         bool "Verbose"
         
 endchoice
-
 
 endmenu

--- a/components/arduino-esp32/CMakeLists.txt
+++ b/components/arduino-esp32/CMakeLists.txt
@@ -1,8 +1,6 @@
 set( src_dirs
-  "variants/esp32"
   "cores/esp32"
   "libraries/EEPROM/src"
-  "libraries/ESP32/src"
   "libraries/FFat/src"
   "libraries/FS/src"
   "libraries/Preferences/src"

--- a/components/eglib/CMakeLists.txt
+++ b/components/eglib/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRC_DIRS "." "eglib" "eglib/display" "eglib/drawing" "eglib/drawing/fonts" "eglib/drawing/fonts/adobe" "eglib/drawing/fonts/freefont" "eglib/drawing/fonts/liberation" "eglib/hal/four_wire_spi/esp32"
+idf_component_register(SRC_DIRS "." "eglib" "eglib/display" "eglib/drawing/fonts/adobe" "eglib/drawing/fonts/freefont" "eglib/drawing/fonts/liberation" "eglib/hal/four_wire_spi/esp32"
                        INCLUDE_DIRS "." "eglib" "eglib/display" "eglib/drawing" "eglib/drawing/fonts" "eglib/drawing/fonts/adobe" "eglib/drawing/fonts/freefont" "eglib/drawing/fonts/liberation" "eglib/hal/four_wire_spi/esp32"
                        REQUIRES arduino-esp32
 )


### PR DESCRIPTION
- fixes I2Cbus log level choise syntax
- removing arduino + eglib source directories which don't contain source files