### PR TITLE
[Display] Print volume upon change

### DIFF
--- a/main/IpsDisplay.h
+++ b/main/IpsDisplay.h
@@ -128,6 +128,7 @@ private:
 	static void drawConnection( int16_t x, int16_t y );
 	static void drawBat( float volt, int x, int y, bool blank );
 	static void drawTemperature( int x, int y, float t );
+	static void drawVolume(int x, int y, int volume );
 	static void drawThermometer( int x, int y );
 	static void drawOneScaleLine(float a, int16_t l1, int16_t l2, int16_t w, uint8_t r, uint8_t g, uint8_t b);
 


### PR DESCRIPTION
Briefly displays the volume upon it changing.

https://github.com/iltis42/XCVario/assets/1118185/1235c8ae-b8c2-4edc-999f-0fab5226f4d9

I liked this feature a lot on the LX Navigation LX166 in my motorglider. It's noisy when the engine is on, and it's nice to know what the volume is turned to.

The one thing I'm a little concerned by is the way I stop drawing the text. I simply clear the display, which feels very hackish. 