### PR TITLE
Create IMU Debug screen

### DIFF
--- a/components/MPUdriver/include/MPU.hpp
+++ b/components/MPUdriver/include/MPU.hpp
@@ -258,6 +258,8 @@ class MPU
     int pi_control(int tick, float xcvTemp);    // PI control to regulate temperatured
     void temp_control(int tick, float xcvTemp);  // Tick hook
     void clearpwm(); // ensure heating is off
+    float getPwm() {return mpu_heat_pwm;}
+    float getImuTemperatureError() {return mpu_t_delta;}
 
     temp_status_t getSiliconTempStatus() {
     	if( abs(mpu_t_delta) < 0.5)

--- a/main/Colors.h
+++ b/main/Colors.h
@@ -18,6 +18,7 @@ extern uint8_t g_col_header_light_b;
 #define COLOR_BLACK g_col_background, g_col_background, g_col_background
 #define COLOR_GREEN 255, 30, 255
 #define COLOR_RED   0,255,255
+#define COLOR_LRED   0,128,128
 #define COLOR_ORANGE 0,125,255
 #define LIGHT_GREEN 127,0,255
 #define COLOR_YELLOW 0, 0, 255

--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -1875,6 +1875,93 @@ void IpsDisplay::drawHorizon( float pitch, float roll, float yaw ){
 	}
 }
 
+void IpsDisplay::drawDebug_IMU(float a_x, float a_y, float a_z, float g_x, float g_y, float g_z, bool hasTemperatureControl, float temperature, float errTemperature, float pwmTemperature)
+{
+	if( !(screens_init & INIT_DISPLAY_DEBUG_IMU) ){
+		ESP_LOGI(FNAME,"Clearing debug 1. screens_init: %d", screens_init);
+		clear();
+		screens_init |= INIT_DISPLAY_DEBUG_IMU;
+	}
+	xSemaphoreTake(spiMutex, portMAX_DELAY);
+
+	ucg->setFont(ucg_font_fur14_hf, true);
+	ucg->setColor( COLOR_WHITE );
+
+	uint16_t lineHeight = 21;
+
+	tick++;
+	if( (tick % 2) == 0 ) {
+
+		char s[100];
+		uint16_t x=15;
+		uint16_t y;
+
+		y = 40;
+		snprintf(s, sizeof(s), "accel [gee]:");
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    x: %6.3f    ", a_x);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    y: %6.3f    ", a_y);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    z: %6.3f    ", a_z);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+
+		y += lineHeight + 2;
+		snprintf(s, sizeof(s), "gyro [deg/s]: ");
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    x: %6.2f    ", g_x);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    y: %6.2f    ", g_y);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		y += lineHeight;
+		snprintf(s, sizeof(s), "    z: %6.2f    ", g_z);
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+
+		y += lineHeight + 2;
+		snprintf(s, sizeof(s), "Temperature control: ");
+		ucg->setPrintPos(x, y);
+		ucg->print(s);
+		if (hasTemperatureControl) {
+			y += lineHeight;
+			snprintf(s, sizeof(s), "    T [C]: %6.1f    ", temperature);
+			ucg->setPrintPos(x, y);
+			ucg->print(s);
+			y += lineHeight;
+			snprintf(s, sizeof(s), "    error [C]: %6.1f    ", errTemperature);
+			ucg->setPrintPos(x, y);
+			ucg->print(s);
+			y += lineHeight;
+			snprintf(s, sizeof(s), "    duty cycle: %6.1f%%    ", pwmTemperature/255*100);
+			ucg->setPrintPos(x, y);
+			ucg->print(s);
+		} else {
+            ucg->setColor( COLOR_LRED );
+            y += lineHeight;
+            snprintf(s, sizeof(s), "    not supported on ");
+            ucg->setPrintPos(x, y);
+            ucg->print(s);
+            y += lineHeight;
+            snprintf(s, sizeof(s), "    this hardware");
+            ucg->setPrintPos(x, y);
+            ucg->print(s);
+		}
+	}
+
+	xSemaphoreGive(spiMutex);
+}
 
 void IpsDisplay::drawLoadDisplay( float loadFactor ){
 	// ESP_LOGI(FNAME,"drawLoadDisplay %1.1f tick: %d", loadFactor, tick );

--- a/main/IpsDisplay.h
+++ b/main/IpsDisplay.h
@@ -22,7 +22,7 @@
 
 enum ips_display { ILI9341 };
 
-typedef enum e_sreens { INIT_DISPLAY_NULL, INIT_DISPLAY_AIRLINER=1, INIT_DISPLAY_RETRO=2, INIT_DISPLAY_FLARM=4, INIT_DISPLAY_GLOAD=8, INIT_DISPLAY_UL=16, INIT_DISPLAY_HORIZON=32 } e_screens_t;
+typedef enum e_sreens { INIT_DISPLAY_NULL, INIT_DISPLAY_AIRLINER=1, INIT_DISPLAY_RETRO=2, INIT_DISPLAY_FLARM=4, INIT_DISPLAY_GLOAD=8, INIT_DISPLAY_UL=16, INIT_DISPLAY_HORIZON=32, INIT_DISPLAY_DEBUG_IMU=64 } e_screens_t;
 extern int screens_init;
 
 class PolarIndicator;
@@ -39,6 +39,7 @@ public:
 	static void drawWarning( const char *warn, bool push=false );
 	static void drawLoadDisplay( float loadFactor );
 	static void drawHorizon( float pitch, float roll, float yaw );
+	static void drawDebug_IMU(float a_x, float a_y, float a_z, float g_x, float g_y, float g_z, bool hasTemperatureControl, float temperature, float errTemperature, float pwmTemperature);
 	static void drawLoadDisplayTexts();
 	static void drawBow( float a, int16_t &old_a_level, int16_t l1, ucg_color_t color );
 	static void initDisplay();

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -1571,6 +1571,10 @@ void SetupMenu::system_menu_create_hardware_rotary_screens( MenuEntry *top ){
 		horizon->addEntry( PROGMEM"Enable");
 		top->addEntry(horizon);
 	}
+	SetupMenuSelect * scrdgbImu = new SetupMenuSelect( PROGMEM"Debug_IMU", RST_NONE, upd_screens, true, &screen_debug_IMU );
+	scrdgbImu->addEntry( PROGMEM"Disable");
+	scrdgbImu->addEntry( PROGMEM"Enable");
+	top->addEntry(scrdgbImu);
 }
 
 void SetupMenu::system_menu_create_hardware_rotary( MenuEntry *top ){

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -103,6 +103,7 @@ void init_screens(){
 	screen_gmeter.set( (scr >> SCREEN_GMETER) & 1);
 	// 	screen_centeraid.set( (scr >> SCREEN_THERMAL_ASSISTANT) & 1);
 	screen_horizon.set( (scr >> SCREEN_HORIZON) & 1);
+	screen_debug_IMU.set( (scr >> SCREEN_DEBUG_IMU) & 1);
 	screen_mask_len = 1; // default vario
 	while( scr ){
 		scr = scr >> 1;
@@ -155,7 +156,8 @@ int upd_screens( SetupMenuSelect * p ){
 	uint32_t screens =
 			( (uint32_t)screen_gmeter.get() << (SCREEN_GMETER)  |
 			//		( (uint32_t)screen_centeraid.get() << (SCREEN_THERMAL_ASSISTANT) ) |
-			( (uint32_t)screen_horizon.get() << (SCREEN_HORIZON) )
+			( (uint32_t)screen_horizon.get() << (SCREEN_HORIZON) ) |
+			( (uint32_t)screen_debug_IMU.get() << (SCREEN_DEBUG_IMU) )
 			);
 	menu_screens.set( screens );
 	// init_screens();

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -384,6 +384,7 @@ SetupNG<int> 			master_xcvario_lock( "MSXCVL", 0 );
 SetupNG<int> 			menu_long_press("MENU_LONG", 0 );
 SetupNG<int> 			menu_screens("MENU_SCR", 0 );
 SetupNG<int> 			screen_gmeter("SCR_GMET", 0, RST_NONE, SYNC_NONE, VOLATILE );
+SetupNG<int> 			screen_debug_IMU("SCR_DBG_IMU", 0, RST_NONE, SYNC_NONE, VOLATILE );
 SetupNG<int> 			screen_horizon("SCR_HORIZ", 0, RST_NONE, SYNC_NONE, VOLATILE );
 SetupNG<int> 			screen_centeraid("SCR_CA", 0, RST_NONE, SYNC_NONE  );
 SetupNG<int> 			data_monitor("DATAMON", MON_OFF, true, SYNC_NONE, VOLATILE  );

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -87,7 +87,7 @@ typedef enum e_volatility { VOLATILE, PERSISTENT, SEMI_VOLATILE } e_volatility_t
 typedef enum e_can_speed { CAN_SPEED_OFF, CAN_SPEED_250KBIT, CAN_SPEED_500KBIT, CAN_SPEED_1MBIT } e_can_speed_t;  // stored in RAM, FLASH, or into FLASH after a while
 typedef enum e_can_mode { CAN_MODE_MASTER, CAN_MODE_CLIENT, CAN_MODE_STANDALONE } e_can_mode_t;
 typedef enum e_altimeter_select { AS_TE_SENSOR, AS_BARO_SENSOR, AS_EXTERNAL } e_altimeter_select_t;
-typedef enum e_menu_screens { SCREEN_VARIO, SCREEN_GMETER, SCREEN_HORIZON, SCREEN_FLARM, SCREEN_THERMAL_ASSISTANT } e_menu_screens_t; // addittional screens
+typedef enum e_menu_screens { SCREEN_VARIO, SCREEN_GMETER, SCREEN_HORIZON, SCREEN_FLARM, SCREEN_THERMAL_ASSISTANT, SCREEN_DEBUG_IMU } e_menu_screens_t; // addittional screens
 typedef enum e_s2f_arrow_color { AC_WHITE_WHITE, AC_BLUE_BLUE, AC_GREEN_RED } e_s2f_arrow_color_t;
 typedef enum e_vario_needle_color { VN_COLOR_WHITE, VN_COLOR_ORANGE, VN_COLOR_RED }  e_vario_needle_color_t;
 typedef enum e_data_monitor { MON_OFF, MON_BLUETOOTH, MON_WIFI_8880, MON_WIFI_8881, MON_WIFI_8882, MON_S1, MON_S2, MON_CAN  }  e_data_monitor_t;
@@ -660,6 +660,7 @@ extern SetupNG<int> 		master_xcvario_lock;
 extern SetupNG<int> 		menu_long_press;
 extern SetupNG<int> 		menu_screens;
 extern SetupNG<int> 		screen_gmeter;
+extern SetupNG<int> 		screen_debug_IMU;
 extern SetupNG<int> 		screen_horizon;
 extern SetupNG<int> 		screen_centeraid;
 extern SetupNG<int> 		data_monitor;

--- a/main/sensor.cpp
+++ b/main/sensor.cpp
@@ -348,6 +348,16 @@ void drawDisplay(void *pvParameters){
 			if( gflags.gLoadDisplay ) {
 				display->drawLoadDisplay( (float)accelG[0] );
 			}
+			if( active_screen == SCREEN_DEBUG_IMU ) {
+				bool hasTemperatureControl = (hardwareRevision.get() == XCVARIO_23);
+				display->drawDebug_IMU(
+					IMU::getRawAccelX(), IMU::getRawAccelY(), IMU::getRawAccelZ(),
+					IMU::getRawGyroX(), IMU::getRawGyroY(), IMU::getRawGyroZ(),
+					hasTemperatureControl, MPU.getTemperature(), MPU.getImuTemperatureError(), MPU.getPwm());
+				gflags.debug_IMU = true;
+			} else {
+				gflags.debug_IMU = false;
+			}
 			if( active_screen == SCREEN_HORIZON ) {
 				float roll = -IMU::getRollRad();
 				float pitch = IMU::getPitchRad();
@@ -373,7 +383,7 @@ void drawDisplay(void *pvParameters){
 				}
 			}
 			// Vario Screen
-			if( !(gflags.stall_warning_active || gflags.gear_warning_active || gflags.flarmWarning || gflags.gLoadDisplay || gflags.horizon )  ) {
+			if( !(gflags.stall_warning_active || gflags.gear_warning_active || gflags.flarmWarning || gflags.gLoadDisplay || gflags.horizon || gflags.debug_IMU )  ) {
 				// ESP_LOGI(FNAME,"TE=%2.3f", te_vario.get() );
 				display->drawDisplay( airspeed, te_vario.get(), aTE, polar_sink, altitude.get(), t, battery, s2f_delta, as2f, average_climb.get(), Switch::getCruiseState(), gflags.standard_setting, flap_pos.get() );
 			}

--- a/main/sensor.h
+++ b/main/sensor.h
@@ -40,6 +40,7 @@ typedef struct global_flags{
 	bool flarmWarning :1 ;
 	bool gLoadDisplay :1;
 	bool horizon :1;
+	bool debug_IMU :1;
 	bool gear_warning_active :1;
 	bool flarmDownload :1 ; // Flarm IGC download flag
 	bool validTemperature :1 ;


### PR DESCRIPTION
Create a debug screen for the IMU:

<img width="634" alt="Screenshot 2023-08-08 at 8 39 15 AM" src="https://github.com/iltis42/XCVario/assets/1118185/2124a369-b8d3-4ac0-9e80-dfef22207ecc">

This is an attempt to add a debug screen, as per https://github.com/iltis42/XCVario/issues/241. It can be activated by `Setup`-->`System`-->`Hardware Setup`-->`Rotary Setup`-->`Screens`-->`Debug_IMU`.

Tested through all combinations of rotary setup screens, works as advertised.

I am not wedded to this particular debug screen, it was simply the easiest way I found to create something in the spirit of #241.

P.S. Also adds a new color, and some getters to the MPU class. This can be split out into other PRs in order to maximize PR atomicity.
