### PR TITLE
keep wiper % same as volume %

### DIFF
--- a/main/ESPAudio.h
+++ b/main/ESPAudio.h
@@ -32,9 +32,10 @@ public:
 	static void setFrequency( float f );
 
 	static void setup();
-	static void incVolume( int steps );
-	static void decVolume( int steps );
+	//static void incVolume( int steps );
+	//static void decVolume( int steps );
 	static void setVolume( int vol );
+	static void setVolumePct( float pct );
 
 	static void alarm( bool enable, int volume=100, e_audio_alarm_type_t alarmType=AUDIO_ALARM_STALL );
 	static bool selfTest();

--- a/main/SetupCommon.cpp
+++ b/main/SetupCommon.cpp
@@ -206,7 +206,7 @@ bool SetupCommon::initSetup( bool& present ) {
 			}
 		}
 	}
-	last_volume = (int)default_volume.get();
+	//last_volume = (int)default_volume.get();
 	giveConfigChanges( 0, true );
 	return ret;
 };

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -89,20 +89,12 @@ void resetCWindAge() {
 		CircleWind::resetAge();
 }
 
-int last_volume=0;
-
 void change_volume() {
-	int delta = (int)audio_volume.get() - last_volume;
-	if( delta ){
-		if( delta > 0 ){
-			Audio::incVolume(delta);
-		}
-		else if( delta < 0 ){
-			Audio::decVolume(-delta);
-		}
-		last_volume += delta;
-		// ESP_LOGI(FNAME,"change_volume, delta=%d last_vol: %d", delta, last_volume );
-	}
+	if (DigitalPoti == nullptr)  // do not set volume until poti set up
+		return;
+	float pct = audio_volume.get();
+	Audio::setVolumePct( pct );
+	ESP_LOGI(FNAME,"change_volume -> %f", pct );
 }
 
 void flap_act() {

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -670,7 +670,7 @@ extern SetupNG<int> 		drawing_prio;
 extern uint8_t g_col_background;
 extern uint8_t g_col_highlight;
 
-extern int last_volume;
+//extern int last_volume;
 
 void change_ballast();
 void change_mc();


### PR DESCRIPTION
Volume changes via increments lets wiper & audio_volume get out of sync.  Revised to set wiper as % of range to audio_volume %.  Resulting code is simpler too.