### PR TITLE
Added menu item to set current volume as default

### DIFF
--- a/main/SetupMenu.h
+++ b/main/SetupMenu.h
@@ -49,6 +49,7 @@ public:
 	static void vario_menu_create_ec( MenuEntry *top );
 
 	static void audio_menu_create( MenuEntry *top );
+	static void audio_menu_create_volume( MenuEntry *top );
 	static void audio_menu_create_tonestyles( MenuEntry *top );
 	static void audio_menu_create_deadbands( MenuEntry *top );
 	static void audio_menu_create_equalizer( MenuEntry *top );


### PR DESCRIPTION
Easier than having to manually adjust the default volume to the current.  Moved the volume options to a submenu to make room for this - which makes the audio menu nicer anyway.