### PR TITLE
Keep audio_volume and speaker_volume aligned...

### DIFF
--- a/main/ESPAudio.h
+++ b/main/ESPAudio.h
@@ -68,7 +68,7 @@ private:
 	static bool _testmode;
 	static bool sound;
     static float _range;
-    static float &speaker_volume;
+    static float speaker_volume;
     static float vario_mode_volume;
     static float s2f_mode_volume;
     static float current_volume;


### PR DESCRIPTION
... even when using split cruise/climb volumes.  Fixed the split-volume mode by making "speaker_volume" a regular variable, not a reference.