### PR TITLE
enforce max_volume...

### DIFF
--- a/main/ESPAudio.cpp
+++ b/main/ESPAudio.cpp
@@ -433,6 +433,8 @@ void Audio::dac_invert_set(dac_channel_t channel, int invert)
 
 
 void Audio::setVolume( float vol ) {
+	if( vol > max_volume.get() )
+		vol = max_volume.get();
 	volume_change = (vol != speaker_volume) ? 100 : 0;
 	speaker_volume = vol;
 	// also copy the new volume into the cruise-mode specific variables so that

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -567,8 +567,8 @@ void SetupMenu::up(int count){
 				vol=3.0;
 			for( int i=0; i<count; i++ )
 				vol = vol * 1.17;
-			if( vol > 100.0 )
-				vol = 100.0;
+			if( vol > max_volume.get() )
+				vol = max_volume.get();
 			audio_volume.set( vol );
 		    // ESP_LOGI(FNAME,"NEW UP VOL: %f", vol );
 		}
@@ -952,6 +952,7 @@ void SetupMenu::audio_menu_create_volume( MenuEntry *top ){
 	    0.0, 100.0, 2.0, vol_adj, false, &audio_volume );
 	// unlike top-level menu volume which exits setup, this returns to parent menu
 	vol->setHelp(PROGMEM"Audio volume level for variometer tone on internal and external speaker");
+	vol->setMax(max_volume.get());   // is this only done at startup?
 	top->addEntry( vol );
 
 	SetupMenuSelect * cdv = new SetupMenuSelect( PROGMEM"Current->Default", RST_NONE, cur_vol_dflt, true );
@@ -2122,6 +2123,7 @@ void SetupMenu::setup_create_root(MenuEntry *top ){
 	else {
 		SetupMenuValFloat * vol = new SetupMenuValFloat( PROGMEM"Audio Volume", "%", 0.0, 100, 1, vol_adj, true, &audio_volume );
 		vol->setHelp(PROGMEM"Audio volume level for variometer tone on internal and external speaker");
+		vol->setMax(max_volume.get());   // is this only done at startup?
 		top->addEntry( vol );
 	}
 

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -952,7 +952,7 @@ void SetupMenu::audio_menu_create_volume( MenuEntry *top ){
 	    0.0, 100.0, 2.0, vol_adj, false, &audio_volume );
 	// unlike top-level menu volume which exits setup, this returns to parent menu
 	vol->setHelp(PROGMEM"Audio volume level for variometer tone on internal and external speaker");
-	vol->setMax(max_volume.get());   // is this only done at startup?
+	vol->setMax(max_volume.get());   // only works after leaving this *parent* menu and returning
 	top->addEntry( vol );
 
 	SetupMenuSelect * cdv = new SetupMenuSelect( PROGMEM"Current->Default", RST_NONE, cur_vol_dflt, true );
@@ -965,9 +965,10 @@ void SetupMenu::audio_menu_create_volume( MenuEntry *top ){
 	top->addEntry( dv );
 	dv->setHelp(PROGMEM"Default volume for Audio when device is switched on");
 
-	SetupMenuValFloat * mv = new SetupMenuValFloat( PROGMEM"Max Volume", "%", 0, 100, 1.0, 0, false, &max_volume );
+// after max_volume exit menu, when re-entering will setMax() volume setting above
+	SetupMenuValFloat * mv = new SetupMenuValFloat( PROGMEM"Max Volume", "%", 0, 100, 1.0, 0, true, &max_volume );
 	top->addEntry( mv );
-	mv->setHelp(PROGMEM"Maximum audio volume setting allowed. Set to 0% to mute audio entirely.");
+	mv->setHelp(PROGMEM"Maximum audio volume setting allowed");
 
 	SetupMenu * audeq = new SetupMenu( PROGMEM"Equalizer" );
 	top->addEntry( audeq );
@@ -2123,7 +2124,7 @@ void SetupMenu::setup_create_root(MenuEntry *top ){
 	else {
 		SetupMenuValFloat * vol = new SetupMenuValFloat( PROGMEM"Audio Volume", "%", 0.0, 100, 1, vol_adj, true, &audio_volume );
 		vol->setHelp(PROGMEM"Audio volume level for variometer tone on internal and external speaker");
-		vol->setMax(max_volume.get());   // is this only done at startup?
+		vol->setMax(max_volume.get());
 		top->addEntry( vol );
 	}
 

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -93,13 +93,16 @@ float last_volume=0;   // is this used?
 
 void change_volume() {
 	float vol = audio_volume.get();
-	float max = max_volume.get();
-	if (vol > max) {
-		audio_volume.set( max );  // will call this function again!
-		return;
-	}
 	Audio::setVolume( vol );
-	ESP_LOGI(FNAME,"change_volume -> %f", audio_volume.get() );
+	ESP_LOGI(FNAME,"change_volume -> %f", vol );
+}
+
+void change_max_volume() {
+	float max = max_volume.get();
+	if ( audio_volume.get() > max ) {   // enforce max_volume
+		audio_volume.set( max );
+		ESP_LOGI(FNAME,"change volume -> %f to fit max", max );
+	}
 }
 
 void flap_act() {
@@ -213,7 +216,7 @@ SetupNG<float>  		core_climb_history( "CORE_CLIMB_HIST" , 45, true, SYNC_FROM_MA
 SetupNG<float>  		mean_climb_major_change( "MEAN_CLMC", 0.5, true, SYNC_FROM_MASTER );
 SetupNG<float>  		elevation( "ELEVATION", -1, true, SYNC_BIDIR, PERSISTENT, 0, UNIT_ALT );
 SetupNG<float>  		default_volume( "DEFAULT_VOL", 25.0 );
-SetupNG<float>  		max_volume( "MAXI_VOL", 60.0 );
+SetupNG<float>  		max_volume( "MAXI_VOL", 60.0, true, SYNC_NONE, PERSISTENT, change_max_volume );
 SetupNG<float>  		frequency_response( "FREQ_RES", 30.0 );
 SetupNG<float>  		s2f_deadband( "DEADBAND_S2F", 10.0, true, SYNC_BIDIR, PERSISTENT, 0, UNIT_SPEED );
 SetupNG<float>  		s2f_deadband_neg( "DB_S2F_NEG", -10.0, true, SYNC_BIDIR, PERSISTENT, 0, UNIT_SPEED );


### PR DESCRIPTION
including adjusting volume menu max to fit max_volume setting, when using rotary outside menu, and adjusting volume if max is reduced to less than current volume