### PR TITLE
avoid crash due to null CAN in IPSdisplay.cpp

### DIFF
--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -951,10 +951,7 @@ void IpsDisplay::drawCable(int16_t x, int16_t y)
 		CANconnectedXCV = CAN->connectedXCV();
 		CANconnectedMag = CAN->connectedMagSens();
 	}
-	if (CANconnectedXCV)
-		ucg->setColor(COLOR_LBLUE);
-	else
-		ucg->setColor(COLOR_MGREY);
+	CANconnectedXCV ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
 	if (CANconnectedMag)
 		ucg->setColor(COLOR_GREEN);
 	// ucg->setFont(ucg_font_fub11_hr);
@@ -963,19 +960,13 @@ void IpsDisplay::drawCable(int16_t x, int16_t y)
 	ucg->drawLine( x-CANW/2, y+CANH/2-1, x+3, y+CANH/2-1 );
 	ucg->drawDisc( x-CANW/2, y+CANH/2, 2, UCG_DRAW_ALL);
 	// ucg->print("c");
-	if (CANconnectedMag)
-		ucg->setColor(COLOR_LBLUE);
-	else
-		ucg->setColor(COLOR_MGREY);
+	CANconnectedMag ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
 	if (Flarm::connected())
 		ucg->setColor(COLOR_GREEN);
 	ucg->drawLine( x+2, y+CANH/2, x-4, y-CANH/2 );
 	ucg->drawLine( x+3, y+CANH/2-1, x-3, y-CANH/2-1 );
 	// ucg->print("a");
-	if (CANconnectedXCV)
-		ucg->setColor(COLOR_LBLUE);
-	else
-		ucg->setColor(COLOR_MGREY);
+	CANconnectedXCV ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
 	ucg->drawLine( x-3, y-CANH/2, x+CANW/2, y-CANH/2 );
 	ucg->drawLine( x-3, y-CANH/2-1, x+CANW/2, y-CANH/2-1 );
 	ucg->drawDisc( x+CANW/2, y-CANH/2, 2, UCG_DRAW_ALL);

--- a/main/IpsDisplay.cpp
+++ b/main/IpsDisplay.cpp
@@ -945,24 +945,37 @@ void IpsDisplay::drawCable(int16_t x, int16_t y)
 {
 	const int16_t CANH = 8;
 	const int16_t CANW = 14;
-	CAN->connectedXCV() ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
+	bool CANconnectedXCV = false;
+	bool CANconnectedMag = false;
+	if (CAN) {
+		CANconnectedXCV = CAN->connectedXCV();
+		CANconnectedMag = CAN->connectedMagSens();
+	}
+	if (CANconnectedXCV)
+		ucg->setColor(COLOR_LBLUE);
+	else
+		ucg->setColor(COLOR_MGREY);
+	if (CANconnectedMag)
+		ucg->setColor(COLOR_GREEN);
 	// ucg->setFont(ucg_font_fub11_hr);
 	// ucg->setPrintPos(x - 8, y);
-	if (CAN->connectedMagSens()) {
-		ucg->setColor(COLOR_GREEN);
-	}
 	ucg->drawLine( x-CANW/2, y+CANH/2, x+3, y+CANH/2 );
 	ucg->drawLine( x-CANW/2, y+CANH/2-1, x+3, y+CANH/2-1 );
 	ucg->drawDisc( x-CANW/2, y+CANH/2, 2, UCG_DRAW_ALL);
 	// ucg->print("c");
-	CAN->connectedMagSens() ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
-	if (Flarm::connected()) {
+	if (CANconnectedMag)
+		ucg->setColor(COLOR_LBLUE);
+	else
+		ucg->setColor(COLOR_MGREY);
+	if (Flarm::connected())
 		ucg->setColor(COLOR_GREEN);
-	}
 	ucg->drawLine( x+2, y+CANH/2, x-4, y-CANH/2 );
 	ucg->drawLine( x+3, y+CANH/2-1, x-3, y-CANH/2-1 );
 	// ucg->print("a");
-	CAN->connectedXCV() ? ucg->setColor(COLOR_LBLUE) : ucg->setColor(COLOR_MGREY);
+	if (CANconnectedXCV)
+		ucg->setColor(COLOR_LBLUE);
+	else
+		ucg->setColor(COLOR_MGREY);
 	ucg->drawLine( x-3, y-CANH/2, x+CANW/2, y-CANH/2 );
 	ucg->drawLine( x-3, y-CANH/2-1, x+CANW/2, y-CANH/2-1 );
 	ucg->drawDisc( x+CANW/2, y-CANH/2, 2, UCG_DRAW_ALL);


### PR DESCRIPTION
IPSdisplay.cpp drawCable() used CAN without checking whether it is null - caused a crash (in my test board at least, after I put it into CAN client mode) - added that check