### PR TITLE
Added SetupMenuSelectCodes

### DIFF
--- a/main/SetupMenuSelect.cpp
+++ b/main/SetupMenuSelect.cpp
@@ -82,7 +82,6 @@ void SetupMenuSelect::addEntryList( const char ent[][4], int size )
 }
 
 void SetupMenuSelect::delEntry( const char* ent ) {
-	int i=0;
 	for( std::vector<const char *>::iterator iter = _values.begin(); iter != _values.end(); ++iter ) {
 		if( std::string(*iter) == std::string(ent) )
 		{
@@ -92,7 +91,6 @@ void SetupMenuSelect::delEntry( const char* ent ) {
 				_select = _numval-1;
 			break;
 		}
-		++i;
 	}
 }
 
@@ -177,7 +175,7 @@ void SetupMenuSelect::display( int mode ){
 			ucg->drawBox( 1,280,240,40 );
 			ucg->setPrintPos( 1, 300 );
 			ucg->setColor( COLOR_WHITE );
-			ucg->print(PROGMEM"Saved" );
+			ucg->print( "Saved" );
 			xSemaphoreGive(spiMutex );
 		}
 		if( mode == 1 )
@@ -333,6 +331,12 @@ int SetupMenuSelectCodes::getSelect() {
 	return (int)_select;
 }
 
+int SetupMenuSelectCodes::getSelectCode() {
+	return _codes.at(_select);
+}
+
+#if 0    // the functions below are not likely to be actually used
+
 void SetupMenuSelectCodes::addEntryList( const char ent[][4], int size )
 {
 	// ESP_LOGI(FNAME,"addEntryList() char ent[][4]");
@@ -394,7 +398,5 @@ void SetupMenuSelectCodes::delEntryByCode( const int code ) {
 		++i;
 	}
 }
-int SetupMenuSelectCodes::getSelectCode() {
-	return _codes.at(_select);
-}
 
+#endif

--- a/main/SetupMenuSelect.h
+++ b/main/SetupMenuSelect.h
@@ -66,12 +66,12 @@ public:
 	       SetupMenuSelect(title, restart, action, save, anvs, ext_handler, end_menu){};
 	void addEntryCode( const char* ent, const int code );
 	void updateEntryCode( const char * ent, int num, const int code );
-	void addEntryList( const char ent[][4], int size );
-	void delEntry( const char* ent );
-	void delEntryByCode( const int code );
 	void setSelect( int sel );
 	int getSelect();
 	int getSelectCode();
+	//void addEntryList( const char ent[][4], int size );
+	//void delEntry( const char* ent );
+	//void delEntryByCode( const int code );
 private:
 	std::vector<int> _codes;
 };

--- a/main/SetupMenuSelect.h
+++ b/main/SetupMenuSelect.h
@@ -16,19 +16,19 @@ struct bitfield_select {
    bool _ext_handler         :1;
    bool _save                :1;
    bool _end_menu            :1;
+   bool _sel_init            :1;
 };
 
 class SetupMenuSelect:  public MenuEntry
 {
 public:
-	SetupMenuSelect();
 	SetupMenuSelect( const char* title, e_restart_mode_t restart=RST_NONE, int (*action)(SetupMenuSelect *p) = 0, bool save=true, SetupNG<int> *anvs=0, bool ext_handler=false, bool end_menu=false );
 	virtual ~SetupMenuSelect();
 	void display( int mode=0 );
 	bool existsEntry( std::string ent );
-    void addEntry( const char* ent );
-	void addEntryList( const char ent[][4], int size );
-	void delEntry( const char * ent );
+	void addEntry( const char* ent );
+	virtual void addEntryList( const char ent[][4], int size );
+	virtual void delEntry( const char * ent );
 	void updateEntry( const char * ent, int num );
 	void up( int count );  // step up to parent
 	void down( int count );
@@ -36,10 +36,14 @@ public:
 	void longPress();
 	void escape() {};
 	const char *value();
-	int getSelect();
-	void setSelect( int sel );
+	virtual int getSelect();
+	virtual void setSelect( int sel );
+	void initSelect();
 	const char * getEntry() const ;
 	int numEntries() { return _numval; };
+	virtual int getSelectCode();
+
+	friend class SetupMenuSelectCodes;  // to be able to access private variables below
 
 private:
 	uint8_t  _select;       // limit to maximum 255 entries, as of today there are e.g. 134 different polars
@@ -49,6 +53,27 @@ private:
 	std::vector<const char *> _values;
 	int (*_action)( SetupMenuSelect *p );
 	SetupNG<int> *_nvs;
+};
+
+// derived class that stores the specified codes:
+
+class SetupMenuSelectCodes: public SetupMenuSelect
+{
+public:
+	SetupMenuSelectCodes( const char* title, e_restart_mode_t restart=RST_NONE,
+	   int (*action)(SetupMenuSelect *p) = 0, bool save=true, SetupNG<int> *anvs=0,
+	   bool ext_handler=false, bool end_menu=false ) :
+	       SetupMenuSelect(title, restart, action, save, anvs, ext_handler, end_menu){};
+	void addEntryCode( const char* ent, const int code );
+	void updateEntryCode( const char * ent, int num, const int code );
+	void addEntryList( const char ent[][4], int size );
+	void delEntry( const char* ent );
+	void delEntryByCode( const int code );
+	void setSelect( int sel );
+	int getSelect();
+	int getSelectCode();
+private:
+	std::vector<int> _codes;
 };
 
 #endif


### PR DESCRIPTION
A variant of SetupMenuSelect that stores the codes along with the labels, allowing arranging the menu as desired, the codes can be non-consecutive and out-of-order.

First implemented within the SetupMenuSelect class, but that (temporarily?) adds a bit of memory use to every select menu, so re-implemented as a derived class, thus no impact at all on use of the original class (for most menus).  That was more work than that was worth, but I learned some things.

Example use:

SetupMenuSelectCodes * btm = new SetupMenuSelectCodes( "Wireless", RST_ON_EXIT, 0, true, &wireless_type );
btm->addEntryCode( "Disable",           WL_DISABLE );           // 0
btm->addEntryCode( "Bluetooth",         WL_BLUETOOTH );         // 1
btm->addEntryCode( "Bluetooth LE",      WL_BLUETOOTH_LE );      // 5
btm->addEntryCode( "WiFi (Standalone)", WL_WLAN_STANDALONE );   // 4
btm->addEntryCode( "WiFi (Master)",     WL_WLAN_MASTER );       // 2
btm->addEntryCode( "WiFi (Client)",     WL_WLAN_CLIENT );       // 3

  - note the order in the menu differs from the order of the codes.  Can choose the order that makes most sense to the users.  Also, if a future platform drops support for classic (non-BLE) Bluetooth, can simply remove the WL_BLUETOOTH line - SetupMenuSelectCodes can handle non-consecutive codes.

