### PR TITLE
no more debris from the horizon line

### DIFF
--- a/main/IpsDisplay.h
+++ b/main/IpsDisplay.h
@@ -155,9 +155,11 @@ private:
 	static void pitch_tick( bool draw, bool major, int pp );
 	static bool pitch_ticks( bool draw );
 	static bool bank_tick( int stage, int x1, int y1, int x2, int y2 );
-	static bool ticks_bank( int stage, bool major, int sinbb, int cosbb, int sbt );
-	static bool bank_ticks( int stage );
+	static bool ticks_bank( int stage, int bank );
+	static bool bank_ticks( bool drawn, bool draw, bool early, int bank );
+	static bool banks_ticks( bool drawn, bool draw, bool early );
 	static void airplane_icon( bool draw );
+	static void erase_horizon_line( bool up0, bool up1 );
 };
 
 // internal functions used by drawHorizon():


### PR DESCRIPTION
When the old and new horizon lines cross, "erases" the old by drawing over it twice, in both sky and ground colors, but with clip ranges that limit each to one part of the line.  (Requires setClipRange().)  Also fixed a bug in the bank ticks erase/not-erase logic.  (Lower-bank tick may be skipped due to overlapping with horizon line while higher-bank tick drawn.)  Also improved the overall procedural structure for better efficiency.  Only 800 lines of code to draw the horizon and ticks!