### PR TITLE
Mix of fixes and minor changes.

### DIFF
--- a/main/KalmanMPU6050.cpp
+++ b/main/KalmanMPU6050.cpp
@@ -22,6 +22,7 @@ double  IMU::filterYaw = 0;
 
 uint64_t IMU::last_rts=0;
 vector_i   IMU::raw_gyro(0,0,0);
+vector_ijk IMU::nogate_gyro(0,0,0);
 vector_ijk IMU::accel(0,0,0);
 vector_ijk IMU::gyro(0,0,0);
 
@@ -324,6 +325,7 @@ esp_err_t IMU::MPU6050Read()
 	else {
 		// Gating ignores Gyro drift < 1 deg per second (default)
 		float gate = gyro_gating.get();
+		nogate_gyro = ref_rot * tmpvec;
 		tmpvec.a = abs(tmpvec.a) < gate ? 0.0 : tmpvec.a;
 		tmpvec.b = abs(tmpvec.b) < gate ? 0.0 : tmpvec.b;
 		tmpvec.c = abs(tmpvec.c) < gate ? 0.0 : tmpvec.c;

--- a/main/KalmanMPU6050.cpp
+++ b/main/KalmanMPU6050.cpp
@@ -322,10 +322,11 @@ esp_err_t IMU::MPU6050Read()
 		err |= ESP_FAIL;
 	}
 	else {
-		// Gating ignores Gyro drift < 2 deg per second
-		tmpvec.a = abs(tmpvec.a*ahrs_gyro_cal.get()) < gyro_gating.get() ? 0.0 : tmpvec.a;
-		tmpvec.b = abs(tmpvec.b*ahrs_gyro_cal.get()) < gyro_gating.get() ? 0.0 : tmpvec.b;
-		tmpvec.c = abs(tmpvec.c*ahrs_gyro_cal.get()) < gyro_gating.get() ? 0.0 : tmpvec.c;
+		// Gating ignores Gyro drift < 1 deg per second (default)
+		float gate = gyro_gating.get();
+		tmpvec.a = abs(tmpvec.a) < gate ? 0.0 : tmpvec.a;
+		tmpvec.b = abs(tmpvec.b) < gate ? 0.0 : tmpvec.b;
+		tmpvec.c = abs(tmpvec.c) < gate ? 0.0 : tmpvec.c;
 		// into glider reference system
 		gyro = ref_rot * tmpvec;
 		// preserve the raw read-out

--- a/main/KalmanMPU6050.cpp
+++ b/main/KalmanMPU6050.cpp
@@ -507,7 +507,7 @@ void IMU::defaultImuReference()
 		accelDefaultRef = Quaternion(deg2rad(180.0f), vector_ijk(1,0,0)) * accelDefaultRef;
 	}
 	ref_rot = accelDefaultRef;
-	// imu_reference.set(ref_rot, false); // nvs
+	imu_reference.set(ref_rot, false); // nvs
 	progress = 0; // reset the calibration procedure
 }
 // Concatenation of ground angle of attack and the basic reference calibration rotation

--- a/main/KalmanMPU6050.h
+++ b/main/KalmanMPU6050.h
@@ -115,6 +115,7 @@ public:
    * @returns The gyroscope X reading in glider reference.
    */
   static inline float getGliderGyroX()   { return gyro.a; };
+  static inline float getGliderNogateGyroX()   { return nogate_gyro.a; };
 
   /**
    * Gets the gyroscope Y reading, as per last read() call.
@@ -122,6 +123,7 @@ public:
    * @returns The gyroscope Y reading.
    */
   static inline float getGliderGyroY()   { return gyro.b; };
+  static inline float getGliderNogateGyroY()   { return nogate_gyro.b; };
 
   /**
    * Gets the gyroscope Z reading, as per last read() call.
@@ -129,6 +131,7 @@ public:
    * @returns The gyroscope Z reading.
    */
   static inline float getGliderGyroZ()   { return gyro.c; };
+  static inline float getGliderNogateGyroZ()   { return nogate_gyro.c; };
 
   // Get the last raw gyro reads
   static inline float getRawGyroX()   { return raw_gyro.a; };
@@ -176,6 +179,7 @@ private:
   static Kalman kalmanZ;
 
   static vector_i   raw_gyro;
+  static vector_ijk nogate_gyro;
   static vector_ijk accel;
   static vector_ijk gyro;
   static vector_ijk petal;

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -143,6 +143,18 @@ int speedcal_change(SetupMenuValFloat * p)
 	return 0;
 }
 
+int set_ahrs_defaults( SetupMenuSelect* p ){
+	if ( p->getSelect() == 1 ) {
+		ahrs_gyro_factor.setDefault();
+		ahrs_min_gyro_factor.setDefault();
+		ahrs_dynamic_factor.setDefault();
+		gyro_gating.setDefault();
+		ahrs_gyro_cal.setDefault();
+	}
+	p->setSelect(0);
+	return 0;
+}
+
 gpio_num_t SetupMenu::getGearWarningIO(){
 	gpio_num_t io = GPIO_NUM_0;
 	if( gear_warning.get() == GW_FLAP_SENSOR || gear_warning.get() == GW_FLAP_SENSOR_INV ){
@@ -1857,7 +1869,7 @@ void SetupMenu::system_menu_create_hardware_ahrs( MenuEntry *top ){
 	top->addEntry( ahrspa );
 	ahrspa->addCreator( system_menu_create_hardware_ahrs_parameter );
 
-	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "AHRS Defaults", RST_NONE, 0, true, &ahrs_defaults );
+	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "AHRS Defaults", RST_NONE, set_ahrs_defaults);
 	top->addEntry( ahrsdef );
 	ahrsdef->setHelp( "Set optimum default values for all AHRS Parameters as determined to the best practice");
 	ahrsdef->addEntry( "Cancel");

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -1709,7 +1709,7 @@ void SetupMenu::system_menu_create_hardware_type( MenuEntry *top ){
 	// Orientation   _display_orientation
 	SetupMenuSelect * diso = new SetupMenuSelect( "Orientation", RST_ON_EXIT, 0, true, &display_orientation );
 	top->addEntry( diso );
-	diso->setHelp( "Display Orientation.  NORMAL means Rotary on right, TOPDOWN means Rotary on left  (reboots). A change will reset the AHRS reference calibration.");
+	diso->setHelp( "Display Orientation.  NORMAL means Rotary on left, TOPDOWN means Rotary on right  (reboots). A change will reset the AHRS reference calibration.");
 	diso->addEntry( "NORMAL");
 	diso->addEntry( "TOPDOWN");
 

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -1840,6 +1840,12 @@ void SetupMenu::system_menu_create_hardware_ahrs_parameter( MenuEntry *top ){
 	gyrocal->setHelp( "Gyro calibration factor to increase accuracy of gyro in %/100");
 	top->addEntry( gyrocal );
 
+	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "Reset to Defaults", RST_NONE, set_ahrs_defaults);
+	top->addEntry( ahrsdef );
+	ahrsdef->setHelp( "Set optimum default values for all AHRS Parameters as determined to the best practice");
+	ahrsdef->addEntry( "Cancel");
+	ahrsdef->addEntry( "Set Defaults");
+
 }
 
 void SetupMenu::system_menu_create_hardware_ahrs( MenuEntry *top ){
@@ -1868,12 +1874,6 @@ void SetupMenu::system_menu_create_hardware_ahrs( MenuEntry *top ){
 	ahrspa->setHelp( "AHRS constants such as gyro trust and filtering", 275 );
 	top->addEntry( ahrspa );
 	ahrspa->addCreator( system_menu_create_hardware_ahrs_parameter );
-
-	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "AHRS Defaults", RST_NONE, set_ahrs_defaults);
-	top->addEntry( ahrsdef );
-	ahrsdef->setHelp( "Set optimum default values for all AHRS Parameters as determined to the best practice");
-	ahrsdef->addEntry( "Cancel");
-	ahrsdef->addEntry( "Set Defaults");
 
 	SetupMenuSelect * rpyl = new SetupMenuSelect( "AHRS RPYL", RST_NONE , 0, true, &ahrs_rpyl_dataset );
 	top->addEntry( rpyl );

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -1835,6 +1835,11 @@ void SetupMenu::system_menu_create_hardware_ahrs_parameter( MenuEntry *top ){
 	gyrog->setHelp( "Minimum accepted gyro rate in degree per second");
 	top->addEntry( gyrog );
 
+	SetupMenuValFloat * tcontrol = new SetupMenuValFloat( "AHRS Temp Control", "", -1, 60, 1, 0, false, &mpu_temperature  );
+	tcontrol->setPrecision( 0 );
+	tcontrol->setHelp( "Regulated target temperature of AHRS silicon chip, if supported in hardware (model > 2023), -1 means OFF");
+	top->addEntry( tcontrol );
+
 	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "Reset to Defaults", RST_NONE, set_ahrs_defaults);
 	top->addEntry( ahrsdef );
 	ahrsdef->setHelp( "Set optimum default values for all AHRS Parameters as determined to the best practice");
@@ -1875,11 +1880,6 @@ void SetupMenu::system_menu_create_hardware_ahrs( MenuEntry *top ){
 	rpyl->setHelp( "Send LEVIL AHRS like $RPYL sentence for artifical horizon");
 	rpyl->addEntry( "Disable");
 	rpyl->addEntry( "Enable");
-
-	SetupMenuValFloat * tcontrol = new SetupMenuValFloat( "AHRS Temp Control", "", -1, 60, 1, 0, false, &mpu_temperature  );
-	tcontrol->setPrecision( 0 );
-	tcontrol->setHelp( "Regulated target temperature of AHRS silicon chip, if supported in hardware (model > 2023), -1 means OFF");
-	top->addEntry( tcontrol );
 }
 
 

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -149,7 +149,6 @@ int set_ahrs_defaults( SetupMenuSelect* p ){
 		ahrs_min_gyro_factor.setDefault();
 		ahrs_dynamic_factor.setDefault();
 		gyro_gating.setDefault();
-		ahrs_gyro_cal.setDefault();
 	}
 	p->setSelect(0);
 	return 0;
@@ -1835,10 +1834,6 @@ void SetupMenu::system_menu_create_hardware_ahrs_parameter( MenuEntry *top ){
 	SetupMenuValFloat * gyrog = new SetupMenuValFloat( "Gyro Gating", "°", 0, 10, 0.1, 0, false, &gyro_gating  );
 	gyrog->setHelp( "Minimum accepted gyro rate in degree per second");
 	top->addEntry( gyrog );
-
-	SetupMenuValFloat * gyrocal = new SetupMenuValFloat( "Gyro Calibration", "", -0.5, 1.5, 0.01, 0, false, &ahrs_gyro_cal  );
-	gyrocal->setHelp( "Gyro calibration factor to increase accuracy of gyro in %/100");
-	top->addEntry( gyrocal );
 
 	SetupMenuSelect * ahrsdef = new SetupMenuSelect( "Reset to Defaults", RST_NONE, set_ahrs_defaults);
 	top->addEntry( ahrsdef );

--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -294,7 +294,9 @@ int add_key( SetupMenuSelect * p )
 
 static int imu_gaa( SetupMenuValFloat* f )
 {
-	IMU::applyImuReference(f->_value, imu_reference.get());
+	if ( ! (imu_reference.get() == Quaternion()) ) {
+		IMU::applyImuReference(f->_value, imu_reference.get());
+	}
 	return 0;
 }
 
@@ -1707,7 +1709,7 @@ void SetupMenu::system_menu_create_hardware_type( MenuEntry *top ){
 	// Orientation   _display_orientation
 	SetupMenuSelect * diso = new SetupMenuSelect( "Orientation", RST_ON_EXIT, 0, true, &display_orientation );
 	top->addEntry( diso );
-	diso->setHelp( "Display Orientation.  NORMAL means Rotary on right, TOPDOWN means Rotary on left  (reboots)");
+	diso->setHelp( "Display Orientation.  NORMAL means Rotary on right, TOPDOWN means Rotary on left  (reboots). A change will reset the AHRS reference calibration.");
 	diso->addEntry( "NORMAL");
 	diso->addEntry( "TOPDOWN");
 

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -128,13 +128,6 @@ void chg_mpu_target(){
 	mpu_target_temp = mpu_temperature.get();
 };
 
-void set_ahrs_defaults(){
-	ahrs_gyro_factor.setDefault();
-	ahrs_min_gyro_factor.setDefault();
-	ahrs_dynamic_factor.setDefault();
-	gyro_gating.setDefault();
-	ahrs_gyro_cal.setDefault();
-}
 
 SetupNG<float>          MC(  "MacCready", 0.5, true, SYNC_BIDIR, PERSISTENT, change_mc, UNIT_VARIO );
 SetupNG<float>  		QNH( "QNH", 1013.25, true, SYNC_BIDIR, PERSISTENT, 0, UNIT_QNH );
@@ -286,7 +279,6 @@ SetupNG<float>		    ahrs_dynamic_factor("AHRSGDYN", 5 );
 SetupNG<int>		    ahrs_roll_check("AHRSRCHECK", 0 );
 SetupNG<float>       	gyro_gating("GYRO_GAT", 1.0 );
 SetupNG<float>  		ahrs_gyro_cal("AHRSGCAL", 1.07 );
-SetupNG<int>  			ahrs_defaults( "AHRSDEF", 0, RST_NONE, SYNC_NONE, VOLATILE, set_ahrs_defaults );
 SetupNG<int>		    display_style("DISPLAY_STYLE", 1 );
 SetupNG<int>		    s2f_switch_type("S2FHWSW", S2F_HW_SWITCH );
 SetupNG<int>		    hardwareRevision("HWREV", HW_UNKNOWN );

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -278,7 +278,6 @@ SetupNG<float>		    ahrs_min_gyro_factor("AHRSLGYF", 20 );
 SetupNG<float>		    ahrs_dynamic_factor("AHRSGDYN", 5 );
 SetupNG<int>		    ahrs_roll_check("AHRSRCHECK", 0 );
 SetupNG<float>       	gyro_gating("GYRO_GAT", 1.0 );
-SetupNG<float>  		ahrs_gyro_cal("AHRSGCAL", 1.07 );
 SetupNG<int>		    display_style("DISPLAY_STYLE", 1 );
 SetupNG<int>		    s2f_switch_type("S2FHWSW", S2F_HW_SWITCH );
 SetupNG<int>		    hardwareRevision("HWREV", HW_UNKNOWN );

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -128,6 +128,11 @@ void chg_mpu_target(){
 	mpu_target_temp = mpu_temperature.get();
 };
 
+void chg_display_orientation(){
+	ESP_LOGI(FNAME, "display changed");
+	imu_reference.setDefault();
+};
+
 
 SetupNG<float>          MC(  "MacCready", 0.5, true, SYNC_BIDIR, PERSISTENT, change_mc, UNIT_VARIO );
 SetupNG<float>  		QNH( "QNH", 1013.25, true, SYNC_BIDIR, PERSISTENT, 0, UNIT_QNH );
@@ -220,7 +225,7 @@ SetupNG<float>  		factory_volt_adjust("FACT_VOLT_ADJ" , 0.00815, RST_NONE );
 
 SetupNG<int>  			display_type( "DISPLAY_TYPE",  UNIVERSAL );
 SetupNG<int>  			display_test( "DISPLAY_TEST", 0, RST_NONE, SYNC_NONE, VOLATILE );
-SetupNG<int>  			display_orientation("DISPLAY_ORIENT" , DISPLAY_NORMAL );
+SetupNG<int>  			display_orientation("DISPLAY_ORIENT" , DISPLAY_NORMAL, true, SYNC_NONE, PERSISTENT, chg_display_orientation );
 SetupNG<int>  			flap_enable( "FLAP_ENABLE", 0, true, SYNC_FROM_MASTER, PERSISTENT, flap_act);
 SetupNG<float>  		flap_minus_3( "FLAP_MINUS_3", 200,  true, SYNC_FROM_MASTER, PERSISTENT, flap_act, UNIT_SPEED );
 SetupNG<float>  		flap_minus_2( "FLAP_MINUS_2", 165,  true, SYNC_FROM_MASTER, PERSISTENT, flap_act, UNIT_SPEED );

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -557,7 +557,6 @@ extern SetupNG<float>		ahrs_min_gyro_factor;
 extern SetupNG<float>		ahrs_dynamic_factor;
 extern SetupNG<int>		    ahrs_roll_check;
 extern SetupNG<float>       gyro_gating;
-extern SetupNG<float>  		ahrs_gyro_cal;
 extern SetupNG<int>		    display_style;
 extern SetupNG<int>		    display_variant;
 extern SetupNG<int>		    s2f_switch_type;

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -557,7 +557,6 @@ extern SetupNG<float>		ahrs_min_gyro_factor;
 extern SetupNG<float>		ahrs_dynamic_factor;
 extern SetupNG<int>		    ahrs_roll_check;
 extern SetupNG<float>       gyro_gating;
-extern SetupNG<int>  		ahrs_defaults;
 extern SetupNG<float>  		ahrs_gyro_cal;
 extern SetupNG<int>		    display_style;
 extern SetupNG<int>		    display_variant;

--- a/main/sensor.cpp
+++ b/main/sensor.cpp
@@ -605,11 +605,11 @@ void readSensors(void *pvParameters){
 			char log[SSTRLEN];
 			sprintf( log, "$SENS;");
 			int pos = strlen(log);
-			sprintf( log+pos, "%ld;%ld;%.3f;%.3f;%.3f;%.2f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f", _millis, _millis - _gps_millis, bp, tp, dynamicP, T, IMU::getGliderAccelX(), IMU::getGliderAccelY(), IMU::getGliderAccelZ(),
-					IMU::getGliderGyroX(), IMU::getGliderGyroY(), IMU::getGliderGyroZ() );
+			sprintf( log+pos, "%ld,%ld,%.3f,%.3f,%.3f,%.2f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f", _millis, _millis - _gps_millis, bp, tp, dynamicP, T, IMU::getGliderAccelX(), IMU::getGliderAccelY(), IMU::getGliderAccelZ(), 
+					IMU::getGliderNogateGyroX(), IMU::getGliderNogateGyroY(), IMU::getGliderNogateGyroZ() );
 			if( compass ){
 				pos=strlen(log);
-				sprintf( log+pos,",%d;%d;%d", int( compass->calX() ),int( compass->calY()) , int( compass->calZ() ));
+				sprintf( log+pos,",%d,%d,%d", int( compass->calX() ),int( compass->calY()) , int( compass->calZ() ));
 			}
 			pos=strlen(log);
 			sprintf( log+pos, "\n");


### PR DESCRIPTION
Fix AHRS ref calib mess up when changing the gaa the wrong moment.
Sort the AHRS parameter menu a bit.
Remove not user gyro calib tuning factor.
Display orientation help text fix.
Raw log w/o gyro gating.