### PR TITLE
BLE workaround for XCsoar

### DIFF
--- a/main/BLESender.cpp
+++ b/main/BLESender.cpp
@@ -32,13 +32,23 @@ uint8_t txValue = 0;
 static TaskHandle_t pid = nullptr;
 static DataLink *dlb;
 
+#if 0
 // See the following for generating UUIDs:
 // https://www.uuidgenerator.net/
-
 #define SERVICE_UUID           "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" // UART service UUID
 #define CHARACTERISTIC_UUID_RX "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
 #define CHARACTERISTIC_UUID_TX "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
-
+#else
+// To work with XCsoar, our UUIDs need to be in XCsoar's whitelist.
+// For now need to pretend to be an HM-10 BT adapter.
+// from XCSoar/android/src/BluetoothUuids.java:
+//  UUID HM10_SERVICE = "0000FFE0-0000-1000-8000-00805F9B34FB"
+// The HM-10 and compatible bluetooth modules use a (single) GATT characteristic
+//    with this UUID for sending and receiving data:
+//  UUID HM10_RX_TX_CHARACTERISTIC = "0000FFE1-0000-1000-8000-00805F9B34FB"
+#define UART_SERVICE_UUID        "0000FFE0-0000-1000-8000-00805F9B34FB"
+#define UART_CHARACTERISTIC_UUID "0000FFE1-0000-1000-8000-00805F9B34FB"
+#endif
 
 class MyServerCallbacks: public BLEServerCallbacks {
 	void onConnect(BLEServer* pServer) {
@@ -57,7 +67,7 @@ class MyCallbacks: public BLECharacteristicCallbacks {
 			dlb->process( rx.c_str(), rx.length(), 7 );
 			DM.monitorString( MON_BLUETOOTH, DIR_RX, rx.c_str(), rx.length() );
 			ESP_LOGI(FNAME,">BT LE RX: %d bytes",  rx.length()  );
-			ESP_LOG_BUFFER_HEXDUMP(FNAME,rx.c_str(), rx.length() , ESP_LOG_INFO);
+			//ESP_LOG_BUFFER_HEXDUMP(FNAME,rx.c_str(), rx.length() , ESP_LOG_INFO);
 		}
 	}
 };
@@ -97,7 +107,7 @@ void BLESender::progress(){
 				pTxCharacteristic->setValue((uint8_t*)&buf[pos], (size_t)sent);
 				pTxCharacteristic->notify();
 				ESP_LOGI(FNAME,"<BT LE TX %d bytes", sent );
-				ESP_LOG_BUFFER_HEXDUMP(FNAME,&buf[pos],len, ESP_LOG_INFO);
+				//ESP_LOG_BUFFER_HEXDUMP(FNAME,&buf[pos],len, ESP_LOG_INFO);
 				DM.monitorString( MON_BLUETOOTH, DIR_TX, &buf[pos], sent );
 				pos+=sent;
 				len-=sent;
@@ -131,22 +141,43 @@ void BLESender::begin(){
 	pServer->setCallbacks(new MyServerCallbacks());
 
 	// Create the BLE Service
+#if 0
 	BLEService *pService = pServer->createService(SERVICE_UUID);
+#else
+	BLEService *pService = pServer->createService(UART_SERVICE_UUID);
+#endif
 
+#if 0
 	// Create a BLE Characteristic
 	pTxCharacteristic = pService->createCharacteristic(
 			CHARACTERISTIC_UUID_TX,
-			BLECharacteristic::PROPERTY_NOTIFY
+			BLECharacteristic::PROPERTY_NOTIFY            // may also need PROPERTY_WRITE_NR
 	);
+#else
+	pTxCharacteristic = pService->createCharacteristic(
+			UART_CHARACTERISTIC_UUID,                     // for both Rx and Tx
+			BLECharacteristic::PROPERTY_READ   |
+			BLECharacteristic::PROPERTY_NOTIFY |
+			BLECharacteristic::PROPERTY_WRITE_NR
+	);
+#endif
 
+// GATT Descriptor 0x2901 Characteristic User Description
+// GATT Descriptor 0x2902 Client Characteristic Configuration
+	BLEDescriptor *pUserDescriptor = new BLEDescriptor("2901");
+	pUserDescriptor->setValue("HMSoft");
+	pTxCharacteristic->addDescriptor(pUserDescriptor);
 	pTxCharacteristic->addDescriptor(new BLE2902());
 
+#if 0
 	BLECharacteristic * pRxCharacteristic = pService->createCharacteristic(
 			CHARACTERISTIC_UUID_RX,
 			BLECharacteristic::PROPERTY_WRITE
 	);
-
 	pRxCharacteristic->setCallbacks(new MyCallbacks());
+#else
+	pTxCharacteristic->setCallbacks(new MyCallbacks());   // for both Rx and Tx
+#endif
 
 	// Start the service
 	pService->start();


### PR DESCRIPTION
Use UUIDs that mimic the (very standard) HM-10 BT adapter, and are listed in XCsoar's whitelist.  Combine Tx & Rx into one "characteristic" because that is what the HM-10 does.  Tested, so far, with Tophat (based on XCsoar 6.8).  Hopefully will also work with other systems such as SeeYou Navigator.