### PR TITLE
Allow wrapping around the ends in SetupMenu

### DIFF
--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -598,8 +598,9 @@ void SetupMenu::down(int count){
 	ucg->setColor(COLOR_BLACK);
 	ucg->drawFrame( 1,(highlight+1)*25+3,238,25 );
 	ucg->setColor(COLOR_WHITE);
-	while( (highlight  > -1) && count ){
-		highlight --;
+	count &= 7;     // limit to some maximum
+	while( /* (highlight  >= -1) && */ count > 0 ){
+		highlight--;
 		count--;
 	}
 	if( highlight < -1 )
@@ -643,8 +644,9 @@ void SetupMenu::up(int count){
 	ucg->setColor(COLOR_BLACK);
 	ucg->drawFrame( 1,(highlight+1)*25+3,238,25 );
 	ucg->setColor(COLOR_WHITE);
-	while( highlight < (int)(_childs.size()-1) && count ){
-		highlight ++;
+	count &= 7;     // limit to some maximum
+	while( /* highlight <= (int)(_childs.size()-1) && */ count > 0 ){
+		highlight++;
 		count--;
 	}
 	if( highlight > (int)(_childs.size()-1) ){


### PR DESCRIPTION
Fixed bug that prevented that - while making the code smaller.  Much more convenient for the users.  In the long list of glider types you only see one at a time, and can scroll through the list as before - maybe can wrap around the end there too, haven't tried.