### PR TITLE
longpress escape from menus

### DIFF
--- a/main/DataMonitor.cpp
+++ b/main/DataMonitor.cpp
@@ -157,11 +157,12 @@ void DataMonitor::press(){
 }
 
 void DataMonitor::longPress(){
-	ESP_LOGI(FNAME,"longPress" );
 	if( !mon_started ){
 		ESP_LOGI(FNAME,"longPress, but not started, return" );
 		return;
 	}
+	ESP_LOGI(FNAME,"longPress" );
+	gflags.ignorePress = true;    // so setup menu will not receive longpress
 	stop();
 	delay( 100 );
 }

--- a/main/ESPRotary.cpp
+++ b/main/ESPRotary.cpp
@@ -14,6 +14,7 @@
 #include <list>
 #include <algorithm>
 #include "Flarm.h"
+#include "sensor.h"
 
 gpio_num_t ESPRotary::clk, ESPRotary::dt;
 gpio_num_t ESPRotary::sw = GPIO_NUM_0;
@@ -144,8 +145,12 @@ void ESPRotary::sendLongPress(){
 	longPressed = true;
 	if( Flarm::bincom )
 		return;
-	for (auto &observer : observers)
+	for (auto &observer : observers) {
 		observer->longPress();
+		if ( gflags.ignorePress )   // press has been consumed
+			break;
+	}
+	gflags.ignorePress = false;
 	// ESP_LOGI(FNAME,"End long pressed action");
 }
 

--- a/main/sensor.cpp
+++ b/main/sensor.cpp
@@ -196,6 +196,17 @@ bool do_factory_reset() {
 
 void drawDisplay(void *pvParameters){
 	while (1) {
+		if ( gflags.escapeSetup ) {       // need to recursively back up out of the menus
+			while ( gflags.inSetup && data_monitor.get()==MON_OFF ) {
+				//ESP_LOGI(FNAME,"drawDisplay() calling selected->longPress()");
+				SetupMenu::selected->longPress();
+				    // longPress() calls showMenu() which steps up to parent
+				    // - can't (?) call showMenu() directly because "selected" points
+				    // to a MenuEntry class object, not the derived SetupMenu class
+				vTaskDelay(20/portTICK_PERIOD_MS);
+			}
+			gflags.escapeSetup = false;   // also already done in showMenu()
+		}
 		if( Flarm::bincom ) {
 			if( gflags.flarmDownload == false ) {
 				gflags.flarmDownload = true;

--- a/main/sensor.h
+++ b/main/sensor.h
@@ -33,6 +33,8 @@
 
 typedef struct global_flags{
 	bool inSetup :1;
+	bool escapeSetup :1;  // long-pressed within menu
+	bool ignorePress :1;  // press or longpress have been consumed
 	bool haveMPU :1;
 	bool ahrsKeyValid  :1;
 	bool gload_alarm :1;


### PR DESCRIPTION
Required 2 new global flag bits, one for escaping status since the menus go out of scope as each one escapes to its parent, and one to avoid interaction with longpress-escape from data monitor.