### PR TITLE
Revert "More efficient wind averaging"

### DIFF
--- a/main/CircleWind.h
+++ b/main/CircleWind.h
@@ -117,7 +117,6 @@ private:
   static int  gpsStatus;
   static Vector minVector;
   static Vector maxVector;
-  static float sumSpeed;
   static Vector result;
   static float jitter;
   static t_circling flightMode;

--- a/main/StraightWind.cpp
+++ b/main/StraightWind.cpp
@@ -56,7 +56,6 @@ deviation_cur(0),
 magneticHeading(0),
 status( "Initial" ),
 jitter(0),
-result(0,0),
 newWindSpeed(0),
 newWindDir(0),
 slipAverage(0),
@@ -309,10 +308,14 @@ void StraightWind::calculateWind( float tc, float gs, float th, float tas, float
 	v.setSpeedKmh( newWindSpeed );
 
 	windVectors.push_back( v );
-	result.add( v );
 	while( windVectors.size() > wind_filter_lowpass.get() ){
-		result.subtract( windVectors.front() );
 		windVectors.pop_front();
+	}
+
+	Vector result = Vector( 0.0, 0.0 );
+	for( auto it=std::begin(windVectors); it != std::end(windVectors); it++ ){
+			result.add( *it );
+			// ESP_LOGI(FNAME,"angle %.1f speed %.1f", it->getAngleDeg(), it->getSpeed() );
 	}
 
 	windDir   = result.getAngleDeg(); // Vector::normalizeDeg( result.getAngleDeg()/circle_wind_lowpass.get() );

--- a/main/StraightWind.h
+++ b/main/StraightWind.h
@@ -89,7 +89,6 @@ private:
 	const char *status;
 	float  jitter;
 	std::list<Vector> windVectors;
-	Vector result;
 	float newWindSpeed;
 	float newWindDir;
 	float slipAverage;

--- a/main/vector.cpp
+++ b/main/vector.cpp
@@ -544,23 +544,6 @@ void Vector::add(Vector arg)
 
 	flags.dirtyDR = true;
 }
-void Vector::subtract(Vector arg)
-{
-	if( arg.flags.dirtyXY )
-	{
-		arg.recalcXY();
-	}
-
-	if( flags.dirtyXY )
-	{
-		recalcXY();
-	}
-
-	_x -= arg.getXMps();
-	_y -= arg.getYMps();
-
-	flags.dirtyDR = true;
-}
 
 
 /** Returns a copy of the object */

--- a/main/vector.h
+++ b/main/vector.h
@@ -195,7 +195,6 @@ public:
      * operator to work properly.
      */
     void add(Vector arg);
-    void subtract(Vector arg);
 
     /**
      * Returns a copy of the object


### PR DESCRIPTION
Reverts iltis42/XCVario#360

With nmeaSim, Circling wind doesn't deliver any result, i see flightMode changes, but now wind results, so reverted as there is a bug:

I (00:00:19.066) UART: uartEnableRxInterrupt: S2
W (00:00:19.165) BMPVario.cpp: Vario time_delta=0.204 sec
I (00:00:19.585) CircleWind.cpp: newConstellation num sat:8
I (00:00:19.626) CircleWind.cpp: gpsStatusChange status:1
I (00:00:19.627) Flarm.cpp: GPRMC, GPS status changed to good, rmc:0,W*47
 gps:1
I (00:00:19.628) Flarm.cpp: Start TimeSync
I (00:04:17.000) Flarm.cpp: Finish Time Sync
I (00:04:20.014) CircleWind.cpp: newFlightMode 1
I (00:04:47.254) CircleWind.cpp: newFlightMode 3
I (00:04:50.281) CircleWind.cpp: newFlightMode 1
I (00:05:02.358) sensor.cpp: Free Heap: 55640 bytes
I (00:05:48.753) CircleWind.cpp: newFlightMode 3
I (00:05:52.357) sensor.cpp: Free Heap: 55640 bytes
I (00:05:56.854) CircleWind.cpp: newFlightMode 1
I (00:06:42.357) sensor.cpp: Free Heap: 55640 bytes
I (00:06:50.301) CircleWind.cpp: newFlightMode 3
I (00:06:56.308) CircleWind.cpp: newFlightMode 1
I (00:07:32.361) sensor.cpp: Free Heap: 55640 bytes
